### PR TITLE
Add option to set the SetupParameters at setup

### DIFF
--- a/source/during/package.d
+++ b/source/during/package.d
@@ -37,11 +37,28 @@ nothrow @nogc:
  */
 int setup(ref Uring uring, uint entries = 128, SetupFlags flags = SetupFlags.NONE) @safe
 {
+    SetupParameters params;
+    params.flags = flags;
+    return setup(uring, entries, params);
+}
+
+/**
+ * Setup new instance of io_uring into provided `Uring` structure.
+ *
+ * Params:
+ *     uring = `Uring` structure to be initialized (must not be already initialized)
+ *     entries = Number of entries to initialize uring with
+ *     params = `SetupParameters` to use to initialize uring.
+ *
+ * Returns: On succes it returns 0, `-errno` otherwise.
+ */
+int setup(ref Uring uring, uint entries, ref SetupParameters params) @safe
+{
     assert(uring.payload is null, "Uring is already initialized");
     uring.payload = () @trusted { return cast(UringDesc*)calloc(1, UringDesc.sizeof); }();
     if (uring.payload is null) return -errno;
 
-    uring.payload.params.flags = flags;
+    uring.payload.params = params;
     uring.payload.refs = 1;
     auto r = io_uring_setup(entries, uring.payload.params);
     if (r < 0) return -errno;

--- a/tests/api.d
+++ b/tests/api.d
@@ -195,6 +195,32 @@ unittest
     assert(io.map!(c => c.user_data).equal(iota(0, 16)));
 }
 
+@("setup parameters")
+unittest
+{
+    import during;
+
+    Uring io;
+    SetupParameters params;
+    params.sq_thread_cpu = 0;
+    params.flags = SetupFlags.SQPOLL | SetupFlags.SQ_AFF;
+
+    auto res = io.setup(16, params);
+    assert(res >= 0, "Error initializing IO");
+
+    res = io.putWith!((ref SubmissionEntry e)
+        {
+            e.prepNop();
+            e.user_data = 43;
+        })
+    .submit(1); // submit and wait for 1 completion
+
+    assert(res == 1); // One operation submitted
+    assert(!io.empty); // one operation returned
+    assert(io.front.user_data == 43);
+    io.popFront();
+}
+
 // @("single mmap")
 // unittest
 // {


### PR DESCRIPTION
This is an alternative approach in the api, it doesn't use a callback but rather adds a second interface without default parameters that sets the entire `SetupParameters`.

It will be slightly worse in terms of performance (copying the struct and doing it also when the user doesn't set it) but setup happens once only and so performance is not that important and the interface is slightly better probably.

Pick whichever you think is better.