### PR TITLE
Catch up to liburing 2.9 / Linux 7.1-rc4

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+# shellcheck shell=bash
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.1; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.1/direnvrc" "sha256-p+fzQdrms/hDa7g+soShAybJNo4bN4SIAeSfqNKgD5I="
+fi
+
+dotenv_if_exists
+
+use flake ".#${DEV_SHELL:-default}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .dub
+build/
 *.o
 *.a
 during-test*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Nix
+.result/
+result
+result-*
+
+# Direnv
+.direnv/
+.env
+
 .dub
 build/
 *.o

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Linux 7.1 catch-up: `SubmissionEntry.write_stream` byte field, `CQEFlags.F_32`
+  (6.18) and `F_TSTAMP_HW` (6.18) plus `IORING_TIMESTAMP_HW_SHIFT` /
+  `TYPE_SHIFT`, `TimeoutFlags.MULTISHOT` (6.4) and `IMMEDIATE_ARG` (6.18),
+  `PollFlags.ADD_LEVEL` (6.0), `CancelFlags.CANCEL_FD_FIXED` (6.1) /
+  `CANCEL_USERDATA` (6.6) / `CANCEL_OP` (6.6), `IORING_ACCEPT_DONTWAIT` /
+  `_POLL_FIRST` (6.6), `IORING_SEND_VECTORIZED` (7.0),
+  `IORING_MSG_RING_CQE_SKIP` (6.5), `IORING_URING_CMD_FIXED` (6.0) /
+  `_MULTISHOT` (6.18) / `_MASK`, all six `IORING_NOP_*` flags (6.13/6.18),
+  `IORING_RW_ATTR_FLAG_PI` (6.13), `EnterFlags.ABS_TIMER` (6.10) /
+  `NO_IOWAIT` (6.16), `RegisterOpCode.REGISTER_ZCRX_CTRL` (6.16),
+  `SetupParameters.PROVIDED_BUFFER_RING_OFFSET` / `_SHIFT` / `MMAP_MASK`.
+- ZCRX scaffolding: `io_uring_zcrx_rqe`, `io_uring_zcrx_cqe`,
+  `io_uring_zcrx_area_reg`, `IORING_ZCRX_AREA_DMABUF`,
+  `IORING_ZCRX_AREA_SHIFT` / `_MASK`, plus the `io_timespec` struct.
+- `io_uring_napi` struct extended with `opcode` and `op_param` fields to match
+  the kernel 6.18 layout; backward-compatible (zero-initialised callers still
+  get the original register/unregister behaviour). New
+  `IO_URING_NAPI_REGISTER_OP` / `STATIC_ADD_ID` / `STATIC_DEL_ID` opcode
+  constants and `TRACKING_DYNAMIC` / `STATIC` / `INACTIVE` strategy constants.
+
+### Tests
+
+- `tests.api nop inject_result drives custom cqe.res` — sets
+  `IORING_NOP_INJECT_RESULT` + `sqe.len` and asserts the value surfaces in
+  `cqe.res`. Kernel-gated on 6.13.
+- `tests.timeout timeout multishot fires repeatedly` — counts three CQEs
+  from a single `MULTISHOT` timeout and asserts only the last lacks
+  `CQEFlags.MORE`. Kernel-gated on 6.4.
+- `tests.timeout timeout immediate_arg accepts inline nanoseconds` — builds
+  a TIMEOUT SQE by hand with `IMMEDIATE_ARG`, puts the duration in
+  `sqe.addr`, asserts `-ETIME`. Kernel-gated on 6.18.
+- `tests.poll poll add_level on pre-readable eventfd` — arms a level-
+  triggered poll on a pre-readable eventfd, asserts the SQE is accepted
+  and completes. Kernel-gated on 6.0.
+
 ## [0.5.0]
 
 Brings the binding up to liburing 2.9 / Linux 6.x parity. 19 new opcodes, 11 new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `UNREGISTER_NAPI` with `Uring.bufRingStatus`, `Uring.registerNapi`,
   `Uring.unregisterNapi` wrappers and backing structs `io_uring_buf_status`,
   `io_uring_napi`.
+- Linux 6.13 ops: `Operation.READV_FIXED`, `WRITEV_FIXED` with `prepReadvFixed`
+  and `prepWritevFixed` helpers.
+- Linux 6.14 op: `Operation.PIPE` with `prepPipe` and `prepPipeDirect`.
+- Linux 6.16 ops: `Operation.NOP128`, `URING_CMD128` with `prepNop128`,
+  `prepUringCmd`, `prepUringCmd128`. Note: a functional NOP128 test is gated
+  on a follow-up fix to the SQE storage path (currently mmaps 64 B/SQE
+  regardless of `SetupFlags.SQE128`).
+- Generic `uring_cmd` helpers: `prepCmdSock`, `prepCmdGetsockname`,
+  `prepCmdDiscard` and `SOCKET_URING_OP_*` / `BLOCK_URING_CMD_DISCARD`
+  subcommand constants.
+- Bundle helpers: `prepSendBundle`, `prepSendSetAddr` and the
+  `IORING_RECVSEND_BUNDLE` flag (Linux 6.10).
+- `prepMsgRingCqeFlags` and the `IORING_MSG_RING_FLAGS_PASS` flag for
+  message-ring CQE flag passthrough (Linux 6.3).
+- Extended `SubmissionEntry` unions to expose `uring_cmd_flags`, `nop_flags`,
+  `pipe_flags`, `optlen`, `addr_len`, `optval`, and the
+  `level`/`optname` overlay required by socket `uring_cmd` ops.
+- Bumped the `Probe` capacity from 64 to 128 ops to make room for the new
+  opcodes.
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `REGISTER_FILE_ALLOC_RANGE` with `Uring.registerSyncCancel` and
   `Uring.registerFileAllocRange` wrappers. Backing structs
   `io_uring_sync_cancel_reg` and `io_uring_file_index_range`.
+- Linux 6.7 ops: `Operation.FIXED_FD_INSTALL`, `FTRUNCATE` and prep helpers
+  `prepFixedFdInstall`, `prepFtruncate`. New `IORING_FIXED_FD_NO_CLOEXEC`
+  flag and `SubmissionEntry.install_fd_flags` union member.
+- Linux 6.11 socket lifecycle ops: `Operation.BIND`, `LISTEN` with
+  `prepBind` and `prepListen` helpers.
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Linux 6.0+ ops: `Operation.SEND_ZC`, `SENDMSG_ZC`, `READ_MULTISHOT`, `WAITID`
+  and the matching prep helpers `prepSendZc`, `prepSendZcFixed`, `prepSendmsgZc`,
+  `prepReadMultishot`, `prepWaitid`.
+- `CQEFlags.NOTIF`, `BUF_MORE`, `SKIP` and the
+  `IORING_NOTIF_USAGE_ZC_COPIED` constant for zero-copy notification CQEs.
+- `SubmissionEntry.waitid_flags` union member.
+
 ## [0.4.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `SubmissionQueue` now allocates the SQE region with the correct stride
+  (64 B for default rings, 128 B for `SetupFlags.SQE128` rings). Previously
+  the mmap was hardcoded at `entries * 64`, which left an SQE128 ring's
+  trailing `cmd[]` payload outside the mapped region — NOP128 and
+  URING_CMD128 were unusable. `SubmissionQueue.sqes` (typed slice) is
+  replaced internally by a `void*` + `entries` + `stride` trio with a
+  `slot(uint)` ref accessor; the put / putWith hot path is unchanged at
+  the call site.
+
 ### Added
 
 - Linux 6.0+ ops: `Operation.SEND_ZC`, `SENDMSG_ZC`, `READ_MULTISHOT`, `WAITID`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   flag and `SubmissionEntry.install_fd_flags` union member.
 - Linux 6.11 socket lifecycle ops: `Operation.BIND`, `LISTEN` with
   `prepBind` and `prepListen` helpers.
+- Linux 6.13 ops: `Operation.RECV_ZC`, `EPOLL_WAIT` with `prepRecvZc` and
+  `prepEpollWait` helpers. New `SubmissionEntry.zcrx_ifq_idx` union member
+  for addressing the zerocopy-RX ifq.
+- Linux 6.8+ register opcodes: `REGISTER_PBUF_STATUS`, `REGISTER_NAPI`,
+  `UNREGISTER_NAPI` with `Uring.bufRingStatus`, `Uring.registerNapi`,
+  `Uring.unregisterNapi` wrappers and backing structs `io_uring_buf_status`,
+  `io_uring_napi`.
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `level`/`optname` overlay required by socket `uring_cmd` ops.
 - Bumped the `Probe` capacity from 64 to 128 ops to make room for the new
   opcodes.
+- Linux 6.10+ register opcodes: `RegisterOpCode.REGISTER_CLOCK`,
+  `REGISTER_CLONE_BUFFERS`, `REGISTER_SEND_MSG_RING`, `REGISTER_ZCRX_IFQ`
+  (6.11), `REGISTER_RESIZE_RINGS` (6.12), `REGISTER_MEM_REGION` (6.13),
+  `REGISTER_QUERY` (6.15), `REGISTER_BPF_FILTER` (6.16) with backing structs
+  `io_uring_clock_register`, `io_uring_clone_buffers`,
+  `io_uring_region_desc`, `io_uring_mem_region_reg`,
+  `io_uring_zcrx_offsets`, `io_uring_zcrx_ifq_reg`, `io_uring_reg_wait`.
+- `Uring` register/wait wrappers: `registerClock`, `cloneBuffers`,
+  `cloneBuffersOffset`, `resizeRings`, `registerMemRegion`,
+  `registerWaitReg`, `submitAndWaitReg`, `submitAndWaitMinTimeout`,
+  `sendMsgRingSync` (static — does not need an initialized `Uring`),
+  `registerIfq`, `registerBpfFilter`.
+- `EnterFlags.EXT_ARG_REG` (Linux 6.13) and the
+  `IORING_REGISTER_SRC_REGISTERED` / `IORING_REGISTER_DST_REPLACE` /
+  `IORING_MEM_REGION_TYPE_USER` / `IORING_MEM_REGION_REG_WAIT_ARG` flag
+  constants.
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0]
+
+Brings the binding up to liburing 2.9 / Linux 6.x parity. 19 new opcodes, 11 new
+register opcodes, 10 new setup flags, 5 new feature bits, plus structural fixes
+for the SQE storage path.
+
 ### Fixed
 
 - `SubmissionQueue` now allocates the SQE region with the correct stride
@@ -86,6 +92,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `HYBRID_IOPOLL` (6.13), `CQE_MIXED` / `SQE_MIXED` / `SQ_REWIND` (6.18).
 - Feature bits: `SetupFeatures.REG_REG_RING` (6.3), `RECVSEND_BUNDLE` (6.10),
   `MIN_TIMEOUT` (6.13), `RW_ATTR` (6.13), `NO_IOWAIT` (6.16).
+- `FUTEX_BITSET_MATCH_ANY` constant and `FUTEX2_MPOL` (kernel 6.18).
+- Examples: `examples/zerocopy_echo` (TCP echo over `SEND_ZC`, asserts the
+  send + notification two-CQE pattern) and `examples/futex_pingpong` (two
+  threads, io_uring `FUTEX_WAIT` woken via legacy `futex(2)` wake).
+
+[0.5.0]: https://github.com/tchaloupka/during/compare/v0.4.0...v0.5.0
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `CQEFlags.NOTIF`, `BUF_MORE`, `SKIP` and the
   `IORING_NOTIF_USAGE_ZC_COPIED` constant for zero-copy notification CQEs.
 - `SubmissionEntry.waitid_flags` union member.
+- Linux 6.7 futex ops: `Operation.FUTEX_WAIT`, `FUTEX_WAKE`, `FUTEX_WAITV` and
+  prep helpers `prepFutexWait`, `prepFutexWake`, `prepFutexWaitv`. New
+  `futex_waitv` struct and `FUTEX2_SIZE_*` / `FUTEX2_PRIVATE` / `FUTEX2_NUMA`
+  constants. `SubmissionEntry.futex_flags` union member.
+- Linux 6.0 register opcodes: `RegisterOpCode.REGISTER_SYNC_CANCEL`,
+  `REGISTER_FILE_ALLOC_RANGE` with `Uring.registerSyncCancel` and
+  `Uring.registerFileAllocRange` wrappers. Backing structs
+  `io_uring_sync_cancel_reg` and `io_uring_file_index_range`.
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `IORING_REGISTER_SRC_REGISTERED` / `IORING_REGISTER_DST_REPLACE` /
   `IORING_MEM_REGION_TYPE_USER` / `IORING_MEM_REGION_REG_WAIT_ARG` flag
   constants.
+- Setup flags: `SetupFlags.SINGLE_ISSUER` (6.0), `DEFER_TASKRUN` (6.1),
+  `NO_MMAP` (6.5), `REGISTERED_FD_ONLY` (6.5), `NO_SQARRAY` (6.6),
+  `HYBRID_IOPOLL` (6.13), `CQE_MIXED` / `SQE_MIXED` / `SQ_REWIND` (6.18).
+- Feature bits: `SetupFeatures.REG_REG_RING` (6.3), `RECVSEND_BUNDLE` (6.10),
+  `MIN_TIMEOUT` (6.13), `RW_ATTR` (6.13), `NO_IOWAIT` (6.16).
 
 ## [0.4.0]
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ Main features:
   * range interface to submit and receive operations
   * helper functions to prepare operations
   * chainable function calls
-* up to date with Linux 5.14
+* up to date with Linux 6.x / liburing 2.9 — full opcode and register-opcode parity
+  (zero-copy networking, futex, socket lifecycle, vectored-fixed I/O, pipe, SQE128,
+  bundles, wait registration, ring resize, buffer cloning, NAPI, BPF filter, …)
 
 **Note:**
 
-* not all operations are properly tested yet (from Kernel 5.4, 5.5, 5.6, 5.7, 5.8)
+* features newer than the host kernel are kernel-gated at runtime in the test suite
+  (tests skip cleanly on older kernels) — use `Uring.probe()` to detect support in your
+  own code
 * PR's are always welcome
 
 ## Docs
@@ -91,14 +95,14 @@ For more examples, see `tests` and `examples` subfolders or the documentation.
 Just add
 
 ```
-dependency "during" version="~>0.1.0"
+dependency "during" version="~>0.5.0"
 ```
 
 to your `dub.sdl` project file, or
 
 ```
 "dependencies": {
-    "during: "~>0.1.0"
+    "during": "~>0.5.0"
 }
 ```
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -5,6 +5,7 @@ license "BSL-1.0"
 homepage "https://github.com/tchaloupka/during"
 copyright "Copyright © 2019, Tomáš Chaloupka"
 targetType "library"
+targetPath "build"
 platforms "linux"
 
 configuration "default" {

--- a/examples/echo_server/.gitignore
+++ b/examples/echo_server/.gitignore
@@ -1,1 +1,0 @@
-echo_server

--- a/examples/echo_server/dub.sdl
+++ b/examples/echo_server/dub.sdl
@@ -1,4 +1,5 @@
 name "echo_server"
+targetPath "build"
 
 dependency "during" path="../.."
 dependency "mempooled" version="~>0.4.0"

--- a/examples/futex_pingpong/dub.sdl
+++ b/examples/futex_pingpong/dub.sdl
@@ -1,0 +1,5 @@
+name "futex_pingpong"
+description "Two threads, futex wait/wake driven by io_uring"
+targetPath "build"
+
+dependency "during" path="../.."

--- a/examples/futex_pingpong/dub.selections.json
+++ b/examples/futex_pingpong/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"during": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/futex_pingpong/source/app.d
+++ b/examples/futex_pingpong/source/app.d
@@ -1,0 +1,101 @@
+/*
+ * Two-thread futex ping-pong driven by io_uring. The main thread submits an
+ * `IORING_OP_FUTEX_WAIT` against a 32-bit private futex, and a helper pthread issues a
+ * legacy `futex(SYS_futex, FUTEX_WAKE_PRIVATE, …)` to wake it. The kernel io_uring FUTEX2
+ * waiter and the legacy futex(2) waker share the same hash bucket, so this works on any
+ * kernel that exposes `IORING_OP_FUTEX_WAIT` (Linux 6.7+).
+ *
+ * The helper retries every 5ms (bounded to ~1s) to defeat the inherent race between SQE
+ * submission and the kernel actually parking the waiter. Run as `dub run` from this directory.
+ */
+module futex_pingpong.app;
+
+import during;
+
+import core.stdc.stdio;
+import core.sys.linux.errno;
+import core.sys.posix.pthread;
+import core.sys.posix.unistd : usleep;
+
+version (X86_64) private enum SYS_futex = 202;
+else version (X86) private enum SYS_futex = 240;
+else version (AArch64) private enum SYS_futex = 98;
+else static assert(0, "Unsupported platform");
+
+private enum FUTEX_WAKE         = 1;
+private enum FUTEX_PRIVATE_FLAG = 128;
+private enum FUTEX_WAKE_PRIVATE = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
+
+private extern (C) int syscall(int sysno, ...) nothrow @nogc @system;
+
+private struct WakeCtx
+{
+    uint*       word;
+    shared int  stop;
+    int         attempts;
+}
+
+private extern (C) void* wakeWorker(void* arg) @system nothrow @nogc
+{
+    auto ctx = cast(WakeCtx*)arg;
+    for (int i = 0; i < 200; i++)
+    {
+        import core.atomic : atomicLoad, MemoryOrder;
+        if (atomicLoad!(MemoryOrder.acq)(ctx.stop)) break;
+        usleep(5_000);
+        ctx.attempts = i + 1;
+        syscall(SYS_futex, cast(void*)ctx.word, FUTEX_WAKE_PRIVATE, 1, null, null, 0);
+    }
+    return null;
+}
+
+extern (C) int main()
+{
+    Uring io;
+    auto rs = io.setup();
+    if (rs < 0) { fprintf(stderr, "setup: %d\n", -rs); return 1; }
+
+    uint word = 0;
+    WakeCtx ctx;
+    ctx.word = &word;
+
+    pthread_t tid;
+    if (pthread_create(&tid, null, &wakeWorker, &ctx) != 0)
+    {
+        perror("pthread_create");
+        return 1;
+    }
+
+    io.putWith!(
+        (ref SubmissionEntry e, uint* w)
+        {
+            e.prepFutexWait(w, 0, FUTEX_BITSET_MATCH_ANY, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+            e.user_data = 1;
+        })(&word);
+
+    auto sret = io.submit(1);
+    if (sret != 1) { fprintf(stderr, "submit=%d\n", sret); return 1; }
+
+    io.wait(1);
+    auto cqe = io.front;
+    int res = cqe.res;
+    io.popFront();
+
+    import core.atomic : atomicStore, MemoryOrder;
+    atomicStore!(MemoryOrder.rel)(ctx.stop, 1);
+    pthread_join(tid, null);
+
+    if (res == -EINVAL || res == -EOPNOTSUPP)
+    {
+        printf("kernel does not support FUTEX_WAIT (res=%d)\n", res);
+        return 0;
+    }
+    if (res != 0)
+    {
+        fprintf(stderr, "FUTEX_WAIT failed: %d\n", res);
+        return 1;
+    }
+
+    printf("ok: io_uring FUTEX_WAIT woken by helper thread after %d wake attempt(s)\n", ctx.attempts);
+    return 0;
+}

--- a/examples/zerocopy_echo/dub.sdl
+++ b/examples/zerocopy_echo/dub.sdl
@@ -1,0 +1,5 @@
+name "zerocopy_echo"
+description "TCP echo over IORING_OP_SEND_ZC"
+targetPath "build"
+
+dependency "during" path="../.."

--- a/examples/zerocopy_echo/dub.selections.json
+++ b/examples/zerocopy_echo/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"during": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/zerocopy_echo/source/app.d
+++ b/examples/zerocopy_echo/source/app.d
@@ -1,0 +1,112 @@
+/*
+ * One-shot TCP echo using `IORING_OP_SEND_ZC`. A child task connects to 127.0.0.1, the
+ * parent accepts, echoes the payload back zero-copy, and the example asserts the per-send
+ * "two CQE" pattern: a transfer-result CQE with `CQEFlags.MORE`, followed by a notification
+ * CQE with `CQEFlags.NOTIF`. Run as `dub run` from this directory.
+ *
+ * Requires a kernel that exposes `IORING_OP_SEND_ZC` (Linux 6.0+). On older kernels the
+ * example prints a message and exits 0.
+ */
+module zerocopy_echo.app;
+
+import during;
+
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.sys.linux.errno;
+import core.sys.posix.arpa.inet : htonl;
+import core.sys.posix.netinet.in_;
+import core.sys.posix.sys.socket;
+import core.sys.posix.unistd : close, read, write;
+
+import std.range : iota;
+import std.algorithm : copy, equal, map;
+
+enum N = 4096;
+
+extern (C) int main()
+{
+    int srv = socket(AF_INET, SOCK_STREAM, 0);
+    if (srv < 0) { perror("socket"); return 1; }
+    scope (exit) close(srv);
+
+    int one = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, one.sizeof);
+
+    sockaddr_in saddr;
+    saddr.sin_family = AF_INET;
+    saddr.sin_port = 0;
+    saddr.sin_addr.s_addr = htonl(0x7f000001);
+    if (bind(srv, cast(sockaddr*)&saddr, saddr.sizeof) != 0) { perror("bind"); return 1; }
+    if (listen(srv, 1) != 0) { perror("listen"); return 1; }
+
+    sockaddr_in actual;
+    socklen_t alen = actual.sizeof;
+    if (getsockname(srv, cast(sockaddr*)&actual, &alen) != 0) { perror("getsockname"); return 1; }
+
+    int cli = socket(AF_INET, SOCK_STREAM, 0);
+    if (cli < 0) { perror("socket(cli)"); return 1; }
+    scope (exit) close(cli);
+    if (connect(cli, cast(sockaddr*)&actual, alen) != 0) { perror("connect"); return 1; }
+
+    int acc = accept(srv, null, null);
+    if (acc < 0) { perror("accept"); return 1; }
+    scope (exit) close(acc);
+
+    Uring io;
+    auto rs = io.setup();
+    if (rs < 0) { fprintf(stderr, "setup: %d\n", -rs); return 1; }
+
+    ubyte[N] payload;
+    iota(0, N).map!(a => cast(ubyte)(a & 0xff)).copy(payload[]);
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd, ubyte[] buf)
+        {
+            e.prepSendZc(fd, buf, MsgFlags.NONE, IORING_SEND_ZC_REPORT_USAGE);
+            e.user_data = 1;
+        })(cli, payload[]);
+
+    auto sret = io.submit(0);
+    if (sret != 1) { fprintf(stderr, "submit=%d\n", sret); return 1; }
+
+    int sendRes = int.min;
+    bool gotMore, gotNotif;
+    foreach (_; 0..2)
+    {
+        io.wait(1);
+        auto cqe = io.front;
+        scope (exit) io.popFront();
+        if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        {
+            printf("kernel does not support SEND_ZC (res=%d)\n", cqe.res);
+            return 0;
+        }
+        if (cqe.flags & CQEFlags.NOTIF)
+        {
+            gotNotif = true;
+            uint usage = cast(uint)cqe.res;
+            printf("notif CQE: %s\n",
+                (usage & IORING_NOTIF_USAGE_ZC_COPIED) ? "kernel copied".ptr : "true zero-copy".ptr);
+        }
+        else
+        {
+            if (cqe.res < 0) { fprintf(stderr, "send: %d\n", cqe.res); return 1; }
+            sendRes = cqe.res;
+            gotMore = (cqe.flags & CQEFlags.MORE) != 0;
+            printf("send CQE: %d bytes, F_MORE=%d\n", sendRes, gotMore);
+        }
+    }
+
+    if (!gotMore) { fprintf(stderr, "send CQE lacks F_MORE\n"); return 1; }
+    if (!gotNotif) { fprintf(stderr, "missing F_NOTIF CQE\n"); return 1; }
+    if (sendRes != N) { fprintf(stderr, "short write: %d\n", sendRes); return 1; }
+
+    ubyte[N] rx;
+    auto rd = read(acc, &rx[0], rx.length);
+    if (rd != N) { fprintf(stderr, "short read: %ld\n", rd); return 1; }
+    if (!rx[].equal(payload[])) { fprintf(stderr, "payload mismatch\n"); return 1; }
+
+    printf("ok: zero-copy echo of %d bytes\n", N);
+    return 0;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1776166891,
+        "narHash": "sha256-bI8yrEGjrohR5hkQox7UrxDH7XqrYMwI8SL/LrJ1+S8=",
+        "owner": "nix-systems",
+        "repo": "triplet",
+        "rev": "6de7bc09397911ce03636afbcf6118745ab2cda0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "triplet",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "DPDK D development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=549bd84d6279f9852cae6225e372cc67fb91a4c1";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    systems.url = "github:nix-systems/triplet";
+  };
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+      perSystem =
+        { config, pkgs, ... }:
+        {
+          devShells.default = pkgs.mkShell {
+            packages = [
+              # D toolchain
+              pkgs.ldc
+              pkgs.dub
+              pkgs.dtools
+            ];
+          };
+        };
+    };
+}

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -64,6 +64,7 @@ struct SubmissionEntry
         uint                hardlink_flags;     /// from Linux 5.15
         uint                xattr_flags;        /// from Linux 5.19
         uint                msg_ring_flags;     /// from Linux 6.0
+        uint                futex_flags;        /// from Linux 6.1
         uint                waitid_flags;       /// from Linux 6.5
     }
 
@@ -609,6 +610,11 @@ enum Operation : ubyte
 
     // available from Linux 6.5
     WAITID = 50,            /// `IORING_OP_WAITID` - async waitid(2)
+
+    // available from Linux 6.7
+    FUTEX_WAIT = 51,        /// `IORING_OP_FUTEX_WAIT` - async futex(2) FUTEX_WAIT
+    FUTEX_WAKE = 52,        /// `IORING_OP_FUTEX_WAKE` - async futex(2) FUTEX_WAKE
+    FUTEX_WAITV = 53,       /// `IORING_OP_FUTEX_WAITV` - async futex_waitv(2)
 }
 
 /// sqe->flags
@@ -1451,6 +1457,16 @@ enum RegisterOpCode : uint
     /* register ring based provide buffer group */
     REGISTER_PBUF_RING       = 22, /// `IORING_REGISTER_PBUF_RING` (from Linux 5.19)
     UNREGISTER_PBUF_RING     = 23, /// `IORING_UNREGISTER_PBUF_RING` (from Linux 5.19)
+
+    /// `IORING_REGISTER_SYNC_CANCEL` (from Linux 6.0)
+    /// Synchronous request cancellation — caller blocks until the kernel has either canceled
+    /// the matching request(s) or determined there's nothing to cancel.
+    REGISTER_SYNC_CANCEL     = 24,
+
+    /// `IORING_REGISTER_FILE_ALLOC_RANGE` (from Linux 6.0)
+    /// Limit the range of indices within the registered files table used by direct-fd
+    /// allocations (e.g. via `IORING_FILE_INDEX_ALLOC`).
+    REGISTER_FILE_ALLOC_RANGE = 25,
 }
 
 /* io-wq worker categories */
@@ -1599,6 +1615,60 @@ struct io_uring_buf_reg
     ushort      pad;
     ulong[3]    resv;
 }
+
+/**
+ * Argument to `IORING_REGISTER_SYNC_CANCEL`. Synchronously cancels matching in-flight
+ * requests; `addr`, `fd`, `flags`, and `opcode` act as match keys (combined the same way as
+ * `IORING_OP_ASYNC_CANCEL`). `timeout` bounds the cancel wait — `{-1, -1}` means "no timeout".
+ *
+ * Note: Available from Linux 6.0
+ */
+struct io_uring_sync_cancel_reg
+{
+    ulong               addr;
+    int                 fd;
+    uint                flags;
+    KernelTimespec      timeout;
+    ubyte               opcode;
+    ubyte[7]            pad;
+    ulong[3]            pad2;
+}
+
+/**
+ * Argument to `IORING_REGISTER_FILE_ALLOC_RANGE` — restricts the range within the registered
+ * file table used by `IORING_FILE_INDEX_ALLOC`-style direct fd allocations.
+ *
+ * Note: Available from Linux 6.0
+ */
+struct io_uring_file_index_range
+{
+    uint    off;        /// starting offset
+    uint    len;        /// number of slots
+    ulong   resv;
+}
+
+/**
+ * Single entry passed to `IORING_OP_FUTEX_WAITV`. Mirrors `struct futex_waitv` from
+ * `<linux/futex.h>`.
+ *
+ * Note: Available from Linux 6.7
+ */
+struct futex_waitv
+{
+    ulong   val;        /// expected value of the futex
+    ulong   uaddr;      /// pointer to the futex word
+    uint    flags;      /// `FUTEX2_SIZE_*` (+ `FUTEX2_PRIVATE` / `FUTEX2_NUMA`)
+    uint    __reserved;
+}
+
+/// `futex_waitv.flags` and `prepFutex*` `futex_flags` parameter bits.
+/// Match the `FUTEX2_*` constants from `<linux/futex.h>`.
+enum FUTEX2_SIZE_U8     = 0x00; /// 8-bit futex
+enum FUTEX2_SIZE_U16    = 0x01; /// 16-bit futex
+enum FUTEX2_SIZE_U32    = 0x02; /// 32-bit futex (the only size supported on most arches today)
+enum FUTEX2_SIZE_U64    = 0x03; /// 64-bit futex
+enum FUTEX2_NUMA        = 0x04; /// NUMA-aware futex
+enum FUTEX2_PRIVATE     = 0x80; /// process-private (skips NUMA hash lookup)
 
 /**
  * io_uring_restriction->opcode values

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -1088,6 +1088,80 @@ enum SetupFlags : uint
     /// `IORING_SETUP_CQE32`: CQEs are 32 byte
     /// Note: since Linux 5.19
     CQE32 = 1U << 11,
+
+    /**
+     * `IORING_SETUP_SINGLE_ISSUER` (from Linux 6.0)
+     *
+     * Hint that only one task / thread will ever submit on this ring. Lets the kernel skip
+     * synchronisation that would otherwise be needed for shared submission. Misuse (multiple
+     * submitters) is detected and returns `-EEXIST`.
+     */
+    SINGLE_ISSUER = 1U << 12,
+
+    /**
+     * `IORING_SETUP_DEFER_TASKRUN` (from Linux 6.1)
+     *
+     * Defer task_work to run only when the ring is being entered, rather than at the next
+     * kernel/user transition on the submitting task. Eliminates a class of interrupts and
+     * cuts latency for many workloads. Requires `SINGLE_ISSUER`.
+     */
+    DEFER_TASKRUN = 1U << 13,
+
+    /**
+     * `IORING_SETUP_NO_MMAP` (from Linux 6.5)
+     *
+     * Application provides the memory backing the SQ / CQ / SQE rings; the kernel does not
+     * allocate or mmap them. The application passes the pointers via `SetupParameters` and
+     * is responsible for keeping the memory mapped and aligned. Disables `resizeRings`.
+     */
+    NO_MMAP = 1U << 14,
+
+    /**
+     * `IORING_SETUP_REGISTERED_FD_ONLY` (from Linux 6.5)
+     *
+     * The ring fd is only ever accessed via the registered-ring-fd path, never as a real fd.
+     * Allows `io_uring_setup` to skip allocating a real fd at all (it's only put in the
+     * registered-ring slot). Use only when you intend to immediately register the ring fd.
+     */
+    REGISTERED_FD_ONLY = 1U << 15,
+
+    /**
+     * `IORING_SETUP_NO_SQARRAY` (from Linux 6.6)
+     *
+     * Skip the indirect SQ array — head/tail now index the SQE array directly. Saves a small
+     * mmap region. Default for newly-created rings on recent kernels.
+     */
+    NO_SQARRAY = 1U << 16,
+
+    /**
+     * `IORING_SETUP_HYBRID_IOPOLL` (from Linux 6.13)
+     *
+     * Combine `IOPOLL` busy-poll with a fallback to interrupt-driven completion when the
+     * polling task is idle, trading some latency for CPU at low load.
+     */
+    HYBRID_IOPOLL = 1U << 17,
+
+    /**
+     * `IORING_SETUP_CQE_MIXED` (from Linux 6.18)
+     *
+     * Allow a mix of 16- and 32-byte CQEs in the same ring (per-CQE `CQEFlags.F_32` selects).
+     */
+    CQE_MIXED = 1U << 18,
+
+    /**
+     * `IORING_SETUP_SQE_MIXED` (from Linux 6.18)
+     *
+     * Allow a mix of 64- and 128-byte SQEs in the same ring.
+     */
+    SQE_MIXED = 1U << 19,
+
+    /**
+     * `IORING_SETUP_SQ_REWIND` (from Linux 6.18)
+     *
+     * Requires `NO_SQARRAY` and is incompatible with `SQPOLL`. Lets the application rewind
+     * the SQ tail to retry SQEs that have not yet been processed.
+     */
+    SQ_REWIND = 1U << 20,
 }
 
 /// `io_uring_params->features` flags
@@ -1222,6 +1296,28 @@ enum SetupFeatures : uint
 
     /// `IORING_FEAT_LINKED_FILE` (from Linux 5.18)
     LINKED_FILE = 1U << 12,
+
+    /// `IORING_FEAT_REG_REG_RING` (from Linux 6.3)
+    /// The kernel supports `IORING_REGISTER_USE_REGISTERED_RING` — register opcodes can be
+    /// passed the registered-ring fd handle instead of a real fd.
+    REG_REG_RING = 1U << 13,
+
+    /// `IORING_FEAT_RECVSEND_BUNDLE` (from Linux 6.10)
+    /// The kernel recognises `IORING_RECVSEND_BUNDLE` on send/recv SQEs.
+    RECVSEND_BUNDLE = 1U << 14,
+
+    /// `IORING_FEAT_MIN_TIMEOUT` (from Linux 6.13)
+    /// `io_uring_getevents_arg.min_wait_usec` is honoured by the kernel.
+    MIN_TIMEOUT = 1U << 15,
+
+    /// `IORING_FEAT_RW_ATTR` (from Linux 6.13)
+    /// Read/write SQEs support the `attr_ptr` / `attr_type_mask` extension fields.
+    RW_ATTR = 1U << 16,
+
+    /// `IORING_FEAT_NO_IOWAIT` (from Linux 6.16)
+    /// The kernel can be told (via `io_uring_set_iowait`) not to account a ring's blocking
+    /// reads as iowait.
+    NO_IOWAIT = 1U << 17,
 }
 
 /**

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -66,6 +66,7 @@ struct SubmissionEntry
         uint                msg_ring_flags;     /// from Linux 6.0
         uint                futex_flags;        /// from Linux 6.1
         uint                waitid_flags;       /// from Linux 6.5
+        uint                install_fd_flags;   /// from Linux 6.7
     }
 
     ulong user_data;                        /// data to be passed back at completion time
@@ -503,6 +504,10 @@ enum IORING_SEND_ZC_REPORT_USAGE    = 1U << 3;
 /// transfer was performed without a copy.
 enum IORING_NOTIF_USAGE_ZC_COPIED   = 1U << 31;
 
+/// `IORING_OP_FIXED_FD_INSTALL` flags (`sqe->install_fd_flags`). Without this flag the new
+/// real fd is created with `O_CLOEXEC`; setting it skips the close-on-exec bit.
+enum IORING_FIXED_FD_NO_CLOEXEC     = 1U << 0;
+
 /// Accept flags stored in sqe->ioprio (since Linux 5.19)
 enum IORING_ACCEPT_MULTISHOT = 1U << 0;
 
@@ -615,6 +620,12 @@ enum Operation : ubyte
     FUTEX_WAIT = 51,        /// `IORING_OP_FUTEX_WAIT` - async futex(2) FUTEX_WAIT
     FUTEX_WAKE = 52,        /// `IORING_OP_FUTEX_WAKE` - async futex(2) FUTEX_WAKE
     FUTEX_WAITV = 53,       /// `IORING_OP_FUTEX_WAITV` - async futex_waitv(2)
+    FIXED_FD_INSTALL = 54,  /// `IORING_OP_FIXED_FD_INSTALL` - turn a registered direct fd into a real fd
+    FTRUNCATE = 55,         /// `IORING_OP_FTRUNCATE` - async ftruncate(2)
+
+    // available from Linux 6.11
+    BIND = 56,              /// `IORING_OP_BIND` - async bind(2)
+    LISTEN = 57,            /// `IORING_OP_LISTEN` - async listen(2)
 }
 
 /// sqe->flags

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -2080,7 +2080,13 @@ enum FUTEX2_SIZE_U16    = 0x01; /// 16-bit futex
 enum FUTEX2_SIZE_U32    = 0x02; /// 32-bit futex (the only size supported on most arches today)
 enum FUTEX2_SIZE_U64    = 0x03; /// 64-bit futex
 enum FUTEX2_NUMA        = 0x04; /// NUMA-aware futex
+enum FUTEX2_MPOL        = 0x08; /// memory-policy futex (kernel 6.18+)
 enum FUTEX2_PRIVATE     = 0x80; /// process-private (skips NUMA hash lookup)
+
+/// Mask value that matches every waiter, sized to a 32-bit futex word. Equivalent to
+/// `FUTEX_BITSET_MATCH_ANY` from `<linux/futex.h>`. Pass to `prepFutexWait` / `prepFutexWake`
+/// when you don't want bitset-based selective wakes.
+enum FUTEX_BITSET_MATCH_ANY = 0xFFFFFFFFU;
 
 /**
  * io_uring_restriction->opcode values

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -82,7 +82,8 @@ struct SubmissionEntry
     union
     {
         int splice_fd_in;
-        uint file_index;
+        uint file_index;        /// from Linux 5.5
+        uint zcrx_ifq_idx;      /// from Linux 6.8 — index into the registered zcrx ifq table
     }
 
     union
@@ -626,6 +627,10 @@ enum Operation : ubyte
     // available from Linux 6.11
     BIND = 56,              /// `IORING_OP_BIND` - async bind(2)
     LISTEN = 57,            /// `IORING_OP_LISTEN` - async listen(2)
+
+    // available from Linux 6.13
+    RECV_ZC = 58,           /// `IORING_OP_RECV_ZC` - zero-copy receive (requires REGISTER_ZCRX_IFQ)
+    EPOLL_WAIT = 59,        /// `IORING_OP_EPOLL_WAIT` - async epoll_wait(2)
 }
 
 /// sqe->flags
@@ -1478,6 +1483,17 @@ enum RegisterOpCode : uint
     /// Limit the range of indices within the registered files table used by direct-fd
     /// allocations (e.g. via `IORING_FILE_INDEX_ALLOC`).
     REGISTER_FILE_ALLOC_RANGE = 25,
+
+    /// `IORING_REGISTER_PBUF_STATUS` (from Linux 6.8)
+    /// Query the current head index of a provided buffer ring.
+    REGISTER_PBUF_STATUS     = 26,
+
+    /// `IORING_REGISTER_NAPI` (from Linux 6.9)
+    /// Enable NAPI busy polling on the ring for receive-path latency reduction.
+    REGISTER_NAPI            = 27,
+
+    /// `IORING_UNREGISTER_NAPI` (from Linux 6.9)
+    UNREGISTER_NAPI          = 28,
 }
 
 /* io-wq worker categories */
@@ -1670,6 +1686,34 @@ struct futex_waitv
     ulong   uaddr;      /// pointer to the futex word
     uint    flags;      /// `FUTEX2_SIZE_*` (+ `FUTEX2_PRIVATE` / `FUTEX2_NUMA`)
     uint    __reserved;
+}
+
+/**
+ * Argument for `IORING_REGISTER_PBUF_STATUS` — read out the current head index of a provided
+ * buffer ring. Caller sets `buf_group` to the target group; on return `head` holds the kernel's
+ * current head index (i.e. the next buffer the kernel will hand out).
+ *
+ * Note: Available from Linux 6.8
+ */
+struct io_uring_buf_status
+{
+    uint        buf_group;  /// input — group id
+    uint        head;       /// output — current head
+    uint[8]     resv;
+}
+
+/**
+ * Argument for `IORING_REGISTER_NAPI` / `IORING_UNREGISTER_NAPI`. Configures NAPI busy-poll
+ * behaviour for the ring. `busy_poll_to` is the busy-poll timeout in microseconds.
+ *
+ * Note: Available from Linux 6.9
+ */
+struct io_uring_napi
+{
+    uint        busy_poll_to;       /// busy-poll timeout in microseconds
+    ubyte       prefer_busy_poll;   /// boolean: prefer busy polling over interrupts
+    ubyte[3]    pad;
+    ulong       resv;
 }
 
 /// `futex_waitv.flags` and `prepFutex*` `futex_flags` parameter bits.

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -64,6 +64,7 @@ struct SubmissionEntry
         uint                hardlink_flags;     /// from Linux 5.15
         uint                xattr_flags;        /// from Linux 5.19
         uint                msg_ring_flags;     /// from Linux 6.0
+        uint                waitid_flags;       /// from Linux 6.5
     }
 
     ulong user_data;                        /// data to be passed back at completion time
@@ -496,6 +497,11 @@ enum IORING_RECVSEND_FIXED_BUF      = 1U << 2;
 /// (at least partially).
 enum IORING_SEND_ZC_REPORT_USAGE    = 1U << 3;
 
+/// Reported in `cqe.res` of an `IORING_CQE_F_NOTIF` CQE if `IORING_SEND_ZC_REPORT_USAGE` was set
+/// on the request and the send had to fall back to a copy (at least partially). If unset, the
+/// transfer was performed without a copy.
+enum IORING_NOTIF_USAGE_ZC_COPIED   = 1U << 31;
+
 /// Accept flags stored in sqe->ioprio (since Linux 5.19)
 enum IORING_ACCEPT_MULTISHOT = 1U << 0;
 
@@ -593,6 +599,16 @@ enum Operation : ubyte
     GETXATTR = 44,          /// `IORING_OP_GETXATTR` - see getxattr(2)
     SOCKET = 45,            /// `IORING_OP_SOCKET` - see socket(2)
     URING_CMD = 46,         /// `IORING_OP_URING_CMD`
+
+    // available from Linux 6.0
+    SEND_ZC = 47,           /// `IORING_OP_SEND_ZC` - zero-copy send
+    SENDMSG_ZC = 48,        /// `IORING_OP_SENDMSG_ZC` - zero-copy sendmsg
+
+    // available from Linux 6.1
+    READ_MULTISHOT = 49,    /// `IORING_OP_READ_MULTISHOT` - multishot read into a buffer group
+
+    // available from Linux 6.5
+    WAITID = 50,            /// `IORING_OP_WAITID` - async waitid(2)
 }
 
 /// sqe->flags
@@ -761,6 +777,22 @@ enum CQEFlags : uint
     /// `IORING_CQE_F_SOCK_NONEMPTY` (from Linux 5.19)
     /// If set, more data to read after socket recv.
     SOCK_NONEMPTY = 1U << 2,
+
+    /// `IORING_CQE_F_NOTIF` (from Linux 6.0)
+    /// Set for notification CQEs. Used to distinguish the per-send completion
+    /// from the (later) zero-copy notification on `IORING_OP_SEND_ZC` /
+    /// `IORING_OP_SENDMSG_ZC`.
+    NOTIF = 1U << 3,
+
+    /// `IORING_CQE_F_BUF_MORE` (from Linux 6.8)
+    /// If set, the buffer ID set in the completion will be reused for the
+    /// next completion from the same buffer ring (partial consumption).
+    BUF_MORE = 1U << 4,
+
+    /// `IORING_CQE_F_SKIP` (from Linux 6.8)
+    /// If set, the application must ignore this CQE. Used internally for
+    /// chained completions.
+    SKIP = 1U << 5,
 }
 
 enum {

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -104,6 +104,14 @@ struct SubmissionEntry
             ushort addr_len;
             ushort[1] __pad3;
         }
+        /// One-byte payload at the same offset as `addr_len`; selects the write stream for
+        /// rw ops on file systems that expose multiple streams (e.g. zoned namespaces). From
+        /// Linux 7.1.
+        struct
+        {
+            ubyte write_stream;
+            ubyte[3] __pad4;
+        }
     }
 
     union
@@ -420,6 +428,23 @@ enum TimeoutFlags : uint
      * `IORING_TIMEOUT_UPDATE_MASK` (from Linux 5.15)
      */
     UPDATE_MASK = UPDATE | LINK_TIMEOUT_UPDATE,
+
+    /**
+     * `IORING_TIMEOUT_MULTISHOT` (from Linux 6.4)
+     *
+     * Keep firing the timeout repeatedly until cancelled. Each completion carries
+     * `CQEFlags.MORE` while the request remains armed.
+     */
+    MULTISHOT = 1U << 6,
+
+    /**
+     * `IORING_TIMEOUT_IMMEDIATE_ARG` (from Linux 6.18)
+     *
+     * If set, `sqe->addr` is interpreted as a timeout value in nanoseconds rather than a
+     * pointer to a `KernelTimespec`. Lets callers avoid pinning a timespec on the stack
+     * for short relative timeouts.
+     */
+    IMMEDIATE_ARG = 1U << 7,
 }
 
 /**
@@ -476,6 +501,14 @@ enum PollFlags : uint
      * Note: available from Linux 5.13
      */
     UPDATE_USER_DATA = 1U << 2,
+
+    /**
+     * `IORING_POLL_ADD_LEVEL` (from Linux 6.0)
+     *
+     * Switch the poll request from the default edge-triggered semantics to level-triggered.
+     * Useful when arming a poll without first draining the file descriptor.
+     */
+    ADD_LEVEL = 1U << 3,
 }
 
 /**
@@ -502,6 +535,21 @@ enum CancelFlags : uint
     /// Can't be set with IORING_ASYNC_CANCEL_FD, as that's a key selector. Only one may be used at
     /// the time.
     CANCEL_ANY = 1U << 2,
+
+    /// `IORING_ASYNC_CANCEL_FD_FIXED` (from Linux 6.1)
+    /// Like `CANCEL_FD`, but `sqe->fd` is interpreted as a registered-files index.
+    CANCEL_FD_FIXED = 1U << 3,
+
+    /// `IORING_ASYNC_CANCEL_USERDATA` (from Linux 6.6)
+    /// Explicitly key off `user_data` (default for `prepCancel`). Pair with `CANCEL_OP` to
+    /// AND in an opcode match.
+    CANCEL_USERDATA = 1U << 4,
+
+    /// `IORING_ASYNC_CANCEL_OP` (from Linux 6.6)
+    /// Match the cancel against `reg.opcode` (or the SQE's `prepCancel` opcode field) as
+    /// well as the chosen key. Lets callers cancel "all read-like requests" without
+    /// individually tracking their user_data.
+    CANCEL_OP = 1U << 5,
 }
 
 // send/sendmsg and recv/recvmsg flags (sqe->ioprio)
@@ -528,6 +576,10 @@ enum IORING_SEND_ZC_REPORT_USAGE    = 1U << 3;
 /// runs out of buffers. From Linux 6.10.
 enum IORING_RECVSEND_BUNDLE         = 1U << 4;
 
+/// Used with `IORING_OP_SEND` to indicate `sqe->addr` points at a `struct iovec` array. The
+/// effect is similar to `IORING_OP_SENDMSG` without the header overhead. From Linux 7.0.
+enum IORING_SEND_VECTORIZED         = 1U << 5;
+
 /// Reported in `cqe.res` of an `IORING_CQE_F_NOTIF` CQE if `IORING_SEND_ZC_REPORT_USAGE` was set
 /// on the request and the send had to fall back to a copy (at least partially). If unset, the
 /// transfer was performed without a copy.
@@ -546,9 +598,49 @@ enum IO_URING_BPF_FILTER_SZ_STRICT  = 1U << 1;
 /// `io_uring_bpf.cmd_type`: register a classic-BPF filter for an io_uring opcode.
 enum IO_URING_BPF_CMD_FILTER        = 1;
 
+/// `MSG_RING` flag (`sqe->msg_ring_flags`). When set, the target CQE is allocated but not
+/// actually posted — useful for prefetch-style notifications. From Linux 6.5.
+enum IORING_MSG_RING_CQE_SKIP       = 1U << 0;
+
 /// `MSG_RING` flag (`sqe->msg_ring_flags`). When set, the kernel passes the value stored in
 /// `sqe->file_index` as the target CQE's flags field. From Linux 6.3.
 enum IORING_MSG_RING_FLAGS_PASS     = 1U << 1;
+
+/// `IORING_OP_URING_CMD` / `URING_CMD128` flag (`sqe->uring_cmd_flags`). Use the registered
+/// buffer addressed by `sqe->buf_index` for the command's data payload. From Linux 6.0.
+enum IORING_URING_CMD_FIXED         = 1U << 0;
+
+/// `IORING_OP_URING_CMD` flag (from Linux 6.18). Multishot uring_cmd; must be combined with
+/// `IOSQE_BUFFER_SELECT`. Not compatible with `IORING_URING_CMD_FIXED`.
+enum IORING_URING_CMD_MULTISHOT     = 1U << 1;
+
+/// Mask of supported `uring_cmd_flags` bits.
+enum IORING_URING_CMD_MASK          = IORING_URING_CMD_FIXED | IORING_URING_CMD_MULTISHOT;
+
+/// `IORING_OP_NOP` flag (`sqe->nop_flags`). Inject the result code from `sqe->len` into the
+/// CQE's `res` field. Useful for testing error-handling paths. From Linux 6.13.
+enum IORING_NOP_INJECT_RESULT       = 1U << 0;
+
+/// `IORING_OP_NOP` flag — make the NOP go through the file table path (kernel test hook).
+/// From Linux 6.13.
+enum IORING_NOP_FILE                = 1U << 1;
+
+/// `IORING_OP_NOP` flag — make the NOP go through the fixed-files path. From Linux 6.13.
+enum IORING_NOP_FIXED_FILE          = 1U << 2;
+
+/// `IORING_OP_NOP` flag — make the NOP go through the fixed-buffers path. From Linux 6.13.
+enum IORING_NOP_FIXED_BUFFER        = 1U << 3;
+
+/// `IORING_OP_NOP` flag — defer the NOP completion to task_work. From Linux 6.13.
+enum IORING_NOP_TW                  = 1U << 4;
+
+/// `IORING_OP_NOP` flag — post a 32-byte CQE for this NOP. Requires `SetupFlags.CQE32` or
+/// `CQE_MIXED`. From Linux 6.18.
+enum IORING_NOP_CQE32               = 1U << 5;
+
+/// `IORING_RW_ATTR_FLAG_PI` (`sqe->attr_type_mask`). Marks the request as carrying a PI
+/// (protection information) attribute pointed at by `sqe->attr_ptr`. From Linux 6.13.
+enum IORING_RW_ATTR_FLAG_PI         = 1U << 0;
 
 /// Subcommands carried in `sqe->cmd_op` for `IORING_OP_URING_CMD` socket operations.
 enum SOCKET_URING_OP_SIOCINQ      = 0;
@@ -563,7 +655,15 @@ enum SOCKET_URING_OP_GETSOCKNAME  = 5;
 enum BLOCK_URING_CMD_DISCARD      = 0;
 
 /// Accept flags stored in sqe->ioprio (since Linux 5.19)
-enum IORING_ACCEPT_MULTISHOT = 1U << 0;
+enum IORING_ACCEPT_MULTISHOT  = 1U << 0;
+
+/// `IORING_ACCEPT_DONTWAIT` (from Linux 6.6) — never wait, return `-EAGAIN` immediately if
+/// no connection is pending.
+enum IORING_ACCEPT_DONTWAIT   = 1U << 1;
+
+/// `IORING_ACCEPT_POLL_FIRST` (from Linux 6.6) — arm poll first, skip the initial accept
+/// attempt. Reduces useless syscalls in event-loop-style accept patterns.
+enum IORING_ACCEPT_POLL_FIRST = 1U << 2;
 
 /**
  * Flags that can be used with the `accept4(2)` operation.
@@ -879,7 +979,23 @@ enum CQEFlags : uint
     /// If set, the application must ignore this CQE. Used internally for
     /// chained completions.
     SKIP = 1U << 5,
+
+    /// `IORING_CQE_F_32` (from Linux 6.18)
+    /// Marks a 32-byte CQE in a ring configured with `SetupFlags.CQE_MIXED`.
+    F_32 = 1U << 15,
+
+    /// `IORING_CQE_F_TSTAMP_HW` (from Linux 6.18)
+    /// Set on `SOCKET_URING_OP_TX_TIMESTAMP` notification CQEs to indicate the timestamp
+    /// originates from the NIC hardware rather than the kernel software clock.
+    F_TSTAMP_HW = 1U << IORING_TIMESTAMP_HW_SHIFT,
 }
+
+/// Shift used to derive `CQEFlags.F_TSTAMP_HW`. The bit at this position in `cqe->flags`
+/// signals a hardware-sourced timestamp on `SOCKET_URING_OP_TX_TIMESTAMP` CQEs.
+enum IORING_TIMESTAMP_HW_SHIFT   = 16;
+
+/// Shift used to encode the timestamp type bit on TX_TIMESTAMP CQEs.
+enum IORING_TIMESTAMP_TYPE_SHIFT = IORING_TIMESTAMP_HW_SHIFT + 1;
 
 enum {
     CQE_BUFFER_SHIFT = 16, /// Note: available from Linux 5.7
@@ -900,6 +1016,13 @@ struct SetupParameters
     enum ulong COMPLETION_QUEUE_RING_OFFSET = 0x8000000UL;
     /// `IORING_OFF_SQES`: mmap offset for submission entries
     enum ulong SUBMISSION_QUEUE_ENTRIES_OFFSET = 0x10000000UL;
+    /// `IORING_OFF_PBUF_RING`: base mmap offset for provided buffer rings. Combine with a
+    /// per-group offset (`bgid << IORING_OFF_PBUF_SHIFT`). From Linux 6.0.
+    enum ulong PROVIDED_BUFFER_RING_OFFSET   = 0x80000000UL;
+    /// Bit position used to encode the buffer-group id into the mmap offset above.
+    enum uint  PROVIDED_BUFFER_RING_SHIFT    = 16;
+    /// Mask covering the bits used by the magic mmap offsets.
+    enum ulong MMAP_MASK                     = 0xf8000000UL;
 
     /// (output) allocated entries in submission queue
     /// (both ring index `array` and separate entry array at `SUBMISSION_QUEUE_ENTRIES_OFFSET`).
@@ -1683,7 +1806,9 @@ enum RegisterOpCode : uint
     /// Query various aspects of io_uring — see `linux/io_uring/query.h`.
     REGISTER_QUERY           = 35,
 
-    // 36 = IORING_REGISTER_ZCRX_CTRL (auxiliary zcrx configuration, omitted here).
+    /// `IORING_REGISTER_ZCRX_CTRL` (from Linux 6.16)
+    /// Auxiliary zcrx control operations (subcommands defined by `enum zcrx_ctrl_op`).
+    REGISTER_ZCRX_CTRL       = 36,
 
     /// `IORING_REGISTER_BPF_FILTER` (from Linux 6.16)
     /// Register a BPF program that filters completions before they reach userspace.
@@ -1733,6 +1858,14 @@ enum EnterFlags: uint
     ENTER_REGISTERED_RING   = 1U << 4,
 
     /**
+     * `IORING_ENTER_ABS_TIMER` (from Linux 6.10)
+     *
+     * Interpret `io_uring_getevents_arg.ts` as an absolute deadline against the clock
+     * registered with `registerClock` (default `CLOCK_MONOTONIC`).
+     */
+    ABS_TIMER               = 1U << 5,
+
+    /**
      * `IORING_ENTER_EXT_ARG_REG` (from Linux 6.13)
      *
      * Causes `args` to be interpreted as an index into a registered wait-region (see
@@ -1740,6 +1873,14 @@ enum EnterFlags: uint
      * `io_uring_getevents_arg`. Pairs with `IORING_GETEVENTS`.
      */
     EXT_ARG_REG             = 1U << 6,
+
+    /**
+     * `IORING_ENTER_NO_IOWAIT` (from Linux 6.16)
+     *
+     * Tell the kernel not to account time spent blocked in this enter call as iowait. Pairs
+     * with `Uring.setIowait(false)`.
+     */
+    NO_IOWAIT               = 1U << 7,
 }
 
 /// Time specification as defined in kernel headers (used by TIMEOUT operations)
@@ -1754,6 +1895,12 @@ static assert(CompletionQueueRingOffsets.sizeof == 40);
 static assert(SetupParameters.sizeof == 120);
 static assert(SubmissionEntry.sizeof == 64);
 static assert(SubmissionQueueRingOffsets.sizeof == 40);
+static assert(io_uring_napi.sizeof == 16);
+static assert(io_uring_zcrx_rqe.sizeof == 16);
+static assert(io_uring_zcrx_cqe.sizeof == 16);
+static assert(io_uring_zcrx_offsets.sizeof == 32);
+static assert(io_uring_zcrx_area_reg.sizeof == 48);
+static assert(io_timespec.sizeof == 16);
 
 /// Indicating that OP is supported by the kernel
 enum IO_URING_OP_SUPPORTED = 1U << 0;
@@ -1940,18 +2087,85 @@ struct io_uring_buf_status
     uint[8]     resv;
 }
 
+/// `io_uring_napi.opcode` values.
+/// Note: A zero-initialised `io_uring_napi` selects `REGISTER_OP` for backward
+/// compatibility with the original (pre-6.18) two-field layout.
+enum IO_URING_NAPI_REGISTER_OP   = 0;  /// register/unregister (backward-compatible default)
+enum IO_URING_NAPI_STATIC_ADD_ID = 1;  /// add a napi id to the static tracking list
+enum IO_URING_NAPI_STATIC_DEL_ID = 2;  /// remove a napi id from the static tracking list
+
+/// `io_uring_napi.op_param` values when `opcode == IO_URING_NAPI_REGISTER_OP`.
+enum IO_URING_NAPI_TRACKING_DYNAMIC  = 0;
+enum IO_URING_NAPI_TRACKING_STATIC   = 1;
+enum IO_URING_NAPI_TRACKING_INACTIVE = 255;
+
 /**
  * Argument for `IORING_REGISTER_NAPI` / `IORING_UNREGISTER_NAPI`. Configures NAPI busy-poll
  * behaviour for the ring. `busy_poll_to` is the busy-poll timeout in microseconds.
  *
- * Note: Available from Linux 6.9
+ * The struct has a backward-compatible layout: zero-initialised callers leave `opcode` and
+ * `op_param` at 0, selecting the original register/unregister behaviour. Linux 6.18+ users
+ * can write `IO_URING_NAPI_STATIC_*` into `opcode` to manage the static NAPI tracking list.
+ *
+ * Note: Available from Linux 6.9 (extended in 6.18 with opcode/op_param)
  */
 struct io_uring_napi
 {
     uint        busy_poll_to;       /// busy-poll timeout in microseconds
     ubyte       prefer_busy_poll;   /// boolean: prefer busy polling over interrupts
-    ubyte[3]    pad;
-    ulong       resv;
+    ubyte       opcode;             /// `IO_URING_NAPI_*` op selector (6.18+)
+    ubyte[2]    pad;
+    uint        op_param;           /// per-op argument: tracking-strategy or napi id (6.18+)
+    uint        resv;
+}
+
+/**
+ * Unsigned-fields timespec matching `struct io_timespec` from the kernel UAPI. Distinct
+ * from `KernelTimespec` (which uses signed fields, matching `struct __kernel_timespec`).
+ * Used by the TX_TIMESTAMP CQE payload and a few zcrx structs.
+ *
+ * Note: Available from Linux 6.18
+ */
+struct io_timespec
+{
+    ulong       tv_sec;
+    ulong       tv_nsec;
+}
+
+/// Refill queue entry posted by userspace into the zcrx ifq region.
+struct io_uring_zcrx_rqe
+{
+    ulong       off;
+    uint        len;
+    uint        __pad;
+}
+
+/// Completion entry returned by the kernel on the zcrx ifq.
+struct io_uring_zcrx_cqe
+{
+    ulong       off;
+    ulong       __pad;
+}
+
+/// `io_uring_zcrx_area_reg.flags` bits.
+enum IORING_ZCRX_AREA_DMABUF = 1;
+
+/// Bit position of the area id within zcrx offsets. Use `IORING_ZCRX_AREA_MASK` to mask out
+/// the offset bits before extracting the area id with `>> IORING_ZCRX_AREA_SHIFT`.
+enum IORING_ZCRX_AREA_SHIFT = 48;
+
+/// Mask covering the area-id bits of a zcrx offset.
+enum ulong IORING_ZCRX_AREA_MASK = ~(((cast(ulong)1) << IORING_ZCRX_AREA_SHIFT) - 1);
+
+/// Argument for `IORING_REGISTER_ZCRX_IFQ`'s area pointer.
+struct io_uring_zcrx_area_reg
+{
+    ulong       addr;
+    ulong       len;
+    ulong       rq_area_token;
+    uint        flags;          /// see `IORING_ZCRX_AREA_DMABUF`
+    uint        dmabuf_fd;
+    ulong[2]    __resv;
 }
 
 /**

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -537,6 +537,15 @@ enum IORING_NOTIF_USAGE_ZC_COPIED   = 1U << 31;
 /// real fd is created with `O_CLOEXEC`; setting it skips the close-on-exec bit.
 enum IORING_FIXED_FD_NO_CLOEXEC     = 1U << 0;
 
+/// `io_uring_bpf_filter.flags`: deny any operation that has no explicit filter installed.
+enum IO_URING_BPF_FILTER_DENY_REST  = 1U << 0;
+
+/// `io_uring_bpf_filter.flags`: require the caller-provided PDU size to exactly match the op.
+enum IO_URING_BPF_FILTER_SZ_STRICT  = 1U << 1;
+
+/// `io_uring_bpf.cmd_type`: register a classic-BPF filter for an io_uring opcode.
+enum IO_URING_BPF_CMD_FILTER        = 1;
+
 /// `MSG_RING` flag (`sqe->msg_ring_flags`). When set, the kernel passes the value stored in
 /// `sqe->file_index` as the target CQE's flags field. From Linux 6.3.
 enum IORING_MSG_RING_FLAGS_PASS     = 1U << 1;
@@ -1549,6 +1558,40 @@ enum RegisterOpCode : uint
 
     /// `IORING_UNREGISTER_NAPI` (from Linux 6.9)
     UNREGISTER_NAPI          = 28,
+
+    /// `IORING_REGISTER_CLOCK` (from Linux 6.10)
+    /// Select the clock source used by ring-side timeouts.
+    REGISTER_CLOCK           = 29,
+
+    /// `IORING_REGISTER_CLONE_BUFFERS` (from Linux 6.10)
+    /// Clone the registered buffer table from a source ring into this ring.
+    REGISTER_CLONE_BUFFERS   = 30,
+
+    /// `IORING_REGISTER_SEND_MSG_RING` (from Linux 6.10)
+    /// Synchronously send an `IORING_OP_MSG_RING` SQE without owning a ring.
+    REGISTER_SEND_MSG_RING   = 31,
+
+    /// `IORING_REGISTER_ZCRX_IFQ` (from Linux 6.11)
+    /// Register a NIC hardware receive queue for zerocopy RX.
+    REGISTER_ZCRX_IFQ        = 32,
+
+    /// `IORING_REGISTER_RESIZE_RINGS` (from Linux 6.12)
+    /// Resize the SQ / CQ of an existing ring without re-creating it.
+    REGISTER_RESIZE_RINGS    = 33,
+
+    /// `IORING_REGISTER_MEM_REGION` (from Linux 6.13)
+    /// Register a user-provided memory region (currently used by the wait_reg API).
+    REGISTER_MEM_REGION      = 34,
+
+    /// `IORING_REGISTER_QUERY` (from Linux 6.15)
+    /// Query various aspects of io_uring — see `linux/io_uring/query.h`.
+    REGISTER_QUERY           = 35,
+
+    // 36 = IORING_REGISTER_ZCRX_CTRL (auxiliary zcrx configuration, omitted here).
+
+    /// `IORING_REGISTER_BPF_FILTER` (from Linux 6.16)
+    /// Register a BPF program that filters completions before they reach userspace.
+    REGISTER_BPF_FILTER      = 37,
 }
 
 /* io-wq worker categories */
@@ -1592,6 +1635,15 @@ enum EnterFlags: uint
      * support for an io_uring_register(2) API that allows to register the ring fds themselves.
      */
     ENTER_REGISTERED_RING   = 1U << 4,
+
+    /**
+     * `IORING_ENTER_EXT_ARG_REG` (from Linux 6.13)
+     *
+     * Causes `args` to be interpreted as an index into a registered wait-region (see
+     * `Uring.registerWaitReg` / `Uring.submitAndWaitReg`) rather than as a pointer to
+     * `io_uring_getevents_arg`. Pairs with `IORING_GETEVENTS`.
+     */
+    EXT_ARG_REG             = 1U << 6,
 }
 
 /// Time specification as defined in kernel headers (used by TIMEOUT operations)
@@ -1730,6 +1782,41 @@ struct io_uring_file_index_range
 }
 
 /**
+ * Classic-BPF filter registration payload for `IORING_REGISTER_BPF_FILTER`.
+ * `filter_ptr` points at an array of `struct sock_filter` instructions and `filter_len`
+ * is the number of instructions in that array.
+ *
+ * Note: Available from Linux 6.16
+ */
+struct io_uring_bpf_filter
+{
+    uint        opcode;
+    uint        flags;
+    uint        filter_len;
+    ubyte       pdu_size;
+    ubyte[3]    resv;
+    ulong       filter_ptr;
+    ulong[5]    resv2;
+}
+
+static assert(io_uring_bpf_filter.sizeof == 64);
+
+/**
+ * Argument for `IORING_REGISTER_BPF_FILTER`.
+ *
+ * Note: Available from Linux 6.16
+ */
+struct io_uring_bpf
+{
+    ushort                  cmd_type;
+    ushort                  cmd_flags;
+    uint                    resv;
+    io_uring_bpf_filter     filter;
+}
+
+static assert(io_uring_bpf.sizeof == 72);
+
+/**
  * Single entry passed to `IORING_OP_FUTEX_WAITV`. Mirrors `struct futex_waitv` from
  * `<linux/futex.h>`.
  *
@@ -1769,6 +1856,125 @@ struct io_uring_napi
     ubyte       prefer_busy_poll;   /// boolean: prefer busy polling over interrupts
     ubyte[3]    pad;
     ulong       resv;
+}
+
+/**
+ * Argument for `IORING_REGISTER_CLOCK`. `clockid` is a `CLOCK_*` value from `<time.h>`
+ * (e.g. `CLOCK_MONOTONIC`, `CLOCK_REALTIME`, `CLOCK_BOOTTIME`).
+ *
+ * Note: Available from Linux 6.10
+ */
+struct io_uring_clock_register
+{
+    uint        clockid;
+    uint[3]     __resv;
+}
+
+/// `io_uring_clone_buffers.flags` bits.
+enum IORING_REGISTER_SRC_REGISTERED = 1U << 0;
+enum IORING_REGISTER_DST_REPLACE    = 1U << 1;
+
+/**
+ * Argument for `IORING_REGISTER_CLONE_BUFFERS`. Copies `nr` registered buffers from the ring
+ * identified by `src_fd` into this ring starting at slot `dst_off`. `nr == 0` clones all of
+ * source's registered buffers.
+ *
+ * Note: Available from Linux 6.10
+ */
+struct io_uring_clone_buffers
+{
+    uint        src_fd;
+    uint        flags;
+    uint        src_off;
+    uint        dst_off;
+    uint        nr;
+    uint[3]     pad;
+}
+
+/// `io_uring_region_desc.flags` — see `IORING_MEM_REGION_TYPE_USER`.
+enum IORING_MEM_REGION_TYPE_USER = 1;
+
+/// `io_uring_mem_region_reg.flags` bits.
+enum IORING_MEM_REGION_REG_WAIT_ARG = 1;
+
+/**
+ * Descriptor of a memory region exposed to (or owned by) the kernel via
+ * `IORING_REGISTER_MEM_REGION`.
+ *
+ * Note: Available from Linux 6.13
+ */
+struct io_uring_region_desc
+{
+    ulong       user_addr;
+    ulong       size;
+    uint        flags;          /// `IORING_MEM_REGION_TYPE_USER`
+    uint        id;
+    ulong       mmap_offset;
+    ulong[4]    __resv;
+}
+
+/**
+ * Argument for `IORING_REGISTER_MEM_REGION`. `region_uptr` points at the `io_uring_region_desc`.
+ *
+ * Note: Available from Linux 6.13
+ */
+struct io_uring_mem_region_reg
+{
+    ulong       region_uptr;    /// pointer to `io_uring_region_desc`
+    ulong       flags;          /// e.g. `IORING_MEM_REGION_REG_WAIT_ARG`
+    ulong[2]    __resv;
+}
+
+/// Offsets the kernel reports for a registered zcrx interface queue.
+struct io_uring_zcrx_offsets
+{
+    uint        head;
+    uint        tail;
+    uint        rqes;
+    uint        __resv2;
+    ulong[2]    __resv;
+}
+
+/**
+ * Argument for `IORING_REGISTER_ZCRX_IFQ`. Pins a NIC hardware receive queue (`if_idx`/`if_rxq`)
+ * to this ring for zerocopy receive. `area_ptr` and `region_ptr` point at the userspace
+ * buffer area and the io_uring memory region respectively.
+ *
+ * Note: Available from Linux 6.11. Functionally usable only on hosts with a supported NIC.
+ */
+struct io_uring_zcrx_ifq_reg
+{
+    uint        if_idx;
+    uint        if_rxq;
+    uint        rq_entries;
+    uint        flags;
+    ulong       area_ptr;       /// pointer to `io_uring_zcrx_area_reg`
+    ulong       region_ptr;     /// pointer to `io_uring_region_desc`
+    io_uring_zcrx_offsets offsets;
+    uint        zcrx_id;
+    uint        rx_buf_len;
+    ulong[3]    __resv;
+}
+
+/**
+ * Wait-registration entry passed to `IORING_REGISTER_MEM_REGION` with
+ * `IORING_MEM_REGION_REG_WAIT_ARG` set. Each entry pre-configures a wait timeout (`ts`),
+ * minimum wait (`min_wait_usec`), and signal mask for later use via
+ * `Uring.submitAndWaitReg(want, regIndex)`.
+ *
+ * Note: Available from Linux 6.13. Note that liburing 2.9 itself stubs
+ * `io_uring_register_wait_reg` to return `-EINVAL`, so usage today goes through the raw
+ * `MEM_REGION` register opcode.
+ */
+struct io_uring_reg_wait
+{
+    KernelTimespec      ts;
+    uint                min_wait_usec;
+    uint                flags;
+    ulong               sigmask;
+    uint                sigmask_sz;
+    uint[3]             pad;
+    ulong[2]            pad2;
 }
 
 /// `futex_waitv.flags` and `prepFutex*` `futex_flags` parameter bits.

--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -41,6 +41,14 @@ struct SubmissionEntry
     {
         ulong addr;                         /// pointer to buffer or iovecs
         ulong splice_off_in;
+
+        /// For socket `uring_cmd` ops (`SOCKET_URING_OP_*`) the kernel reads `level`/`optname`
+        /// out of this slot. From Linux 6.7.
+        struct
+        {
+            uint    level;
+            uint    optname;
+        }
     }
     uint len;                               /// buffer size or number of iovecs
 
@@ -64,9 +72,12 @@ struct SubmissionEntry
         uint                hardlink_flags;     /// from Linux 5.15
         uint                xattr_flags;        /// from Linux 5.19
         uint                msg_ring_flags;     /// from Linux 6.0
+        uint                uring_cmd_flags;    /// from Linux 6.0
         uint                futex_flags;        /// from Linux 6.1
         uint                waitid_flags;       /// from Linux 6.5
         uint                install_fd_flags;   /// from Linux 6.7
+        uint                nop_flags;          /// from Linux 6.10
+        uint                pipe_flags;         /// from Linux 6.10
     }
 
     ulong user_data;                        /// data to be passed back at completion time
@@ -84,6 +95,15 @@ struct SubmissionEntry
         int splice_fd_in;
         uint file_index;        /// from Linux 5.5
         uint zcrx_ifq_idx;      /// from Linux 6.8 — index into the registered zcrx ifq table
+        uint optlen;            /// from Linux 6.7 — option length for socket cmd ops
+
+        /// `addr_len` is used by `prepSendSetAddr` / `prepSendto` to carry the address length
+        /// for `IORING_OP_SEND`. From Linux 6.7.
+        struct
+        {
+            ushort addr_len;
+            ushort[1] __pad3;
+        }
     }
 
     union
@@ -93,6 +113,8 @@ struct SubmissionEntry
             ulong addr3;
             ulong[1] __pad2;
         }
+        /// `optval` for socket `uring_cmd` SET/GETSOCKOPT ops. From Linux 6.7.
+        ulong optval;
         /*
          * If the ring is initialized with `IORING_SETUP_SQE128`, then
          * this field is used for 80 bytes of arbitrary command data
@@ -500,6 +522,12 @@ enum IORING_RECVSEND_FIXED_BUF      = 1U << 2;
 /// (at least partially).
 enum IORING_SEND_ZC_REPORT_USAGE    = 1U << 3;
 
+/// Used with `IOSQE_BUFFER_SELECT` on `IORING_OP_SEND` / `IORING_OP_RECV` to bundle multiple
+/// messages worth of data from the provided buffer ring into a single submission. Each CQE
+/// reports the per-message result; the operation terminates with `-ENOBUFS` when the ring
+/// runs out of buffers. From Linux 6.10.
+enum IORING_RECVSEND_BUNDLE         = 1U << 4;
+
 /// Reported in `cqe.res` of an `IORING_CQE_F_NOTIF` CQE if `IORING_SEND_ZC_REPORT_USAGE` was set
 /// on the request and the send had to fall back to a copy (at least partially). If unset, the
 /// transfer was performed without a copy.
@@ -508,6 +536,22 @@ enum IORING_NOTIF_USAGE_ZC_COPIED   = 1U << 31;
 /// `IORING_OP_FIXED_FD_INSTALL` flags (`sqe->install_fd_flags`). Without this flag the new
 /// real fd is created with `O_CLOEXEC`; setting it skips the close-on-exec bit.
 enum IORING_FIXED_FD_NO_CLOEXEC     = 1U << 0;
+
+/// `MSG_RING` flag (`sqe->msg_ring_flags`). When set, the kernel passes the value stored in
+/// `sqe->file_index` as the target CQE's flags field. From Linux 6.3.
+enum IORING_MSG_RING_FLAGS_PASS     = 1U << 1;
+
+/// Subcommands carried in `sqe->cmd_op` for `IORING_OP_URING_CMD` socket operations.
+enum SOCKET_URING_OP_SIOCINQ      = 0;
+enum SOCKET_URING_OP_SIOCOUTQ     = 1;
+enum SOCKET_URING_OP_GETSOCKOPT   = 2;
+enum SOCKET_URING_OP_SETSOCKOPT   = 3;
+enum SOCKET_URING_OP_TX_TIMESTAMP = 4;
+enum SOCKET_URING_OP_GETSOCKNAME  = 5;
+
+/// Subcommand carried in `sqe->cmd_op` for `IORING_OP_URING_CMD` issued against a block
+/// device file descriptor. Mirrors `BLOCK_URING_CMD_DISCARD` from `<linux/blkdev.h>`.
+enum BLOCK_URING_CMD_DISCARD      = 0;
 
 /// Accept flags stored in sqe->ioprio (since Linux 5.19)
 enum IORING_ACCEPT_MULTISHOT = 1U << 0;
@@ -631,6 +675,17 @@ enum Operation : ubyte
     // available from Linux 6.13
     RECV_ZC = 58,           /// `IORING_OP_RECV_ZC` - zero-copy receive (requires REGISTER_ZCRX_IFQ)
     EPOLL_WAIT = 59,        /// `IORING_OP_EPOLL_WAIT` - async epoll_wait(2)
+
+    // available from Linux 6.13
+    READV_FIXED = 60,       /// `IORING_OP_READV_FIXED` - vectored read against registered buffers
+    WRITEV_FIXED = 61,      /// `IORING_OP_WRITEV_FIXED` - vectored write against registered buffers
+
+    // available from Linux 6.14
+    PIPE = 62,              /// `IORING_OP_PIPE` - async pipe(2)/pipe2(2)
+
+    // available from Linux 6.16 (SQE128 path)
+    NOP128 = 63,            /// `IORING_OP_NOP128` - 128-byte NOP for testing SQE128 rings
+    URING_CMD128 = 64,      /// `IORING_OP_URING_CMD128` - 128-byte uring_cmd
 }
 
 /// sqe->flags

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -57,6 +57,9 @@ int setup(ref Uring uring, uint entries = 128, SetupFlags flags = SetupFlags.NON
 int setup(ref Uring uring, uint entries, ref const SetupParameters params) @safe
 {
     assert(uring.payload is null, "Uring is already initialized");
+    if (params.flags & (SetupFlags.NO_MMAP | SetupFlags.REGISTERED_FD_ONLY))
+        return -EINVAL; // this wrapper currently owns the ring mmap lifecycle
+
     uring.payload = () @trusted { return cast(UringDesc*)calloc(1, UringDesc.sizeof); }();
     if (uring.payload is null) return -errno;
 
@@ -301,6 +304,20 @@ struct Uring
     }
 
     /**
+     * Advances the userspace submission queue and returns a slot suitable for a 128-byte SQE
+     * (`Operation.NOP128` / `Operation.URING_CMD128`). On `SetupFlags.SQE128` rings this is
+     * equivalent to `next`; on `SetupFlags.SQE_MIXED` rings it reserves two contiguous 64-byte
+     * slots, inserting a skipped NOP if needed to avoid wrapping a 128-byte SQE over the ring end.
+     */
+    ref SubmissionEntry next128()() @safe pure
+    in (payload !is null, "Uring hasn't been initialized yet")
+    in (payload.params.flags & (SetupFlags.SQE128 | SetupFlags.SQE_MIXED),
+        "Ring was not created with SQE128 or SQE_MIXED")
+    {
+        return payload.sq.next128();
+    }
+
+    /**
      * If completion queue is full, the new event maybe dropped.
      * This value records number of dropped events.
      */
@@ -363,6 +380,7 @@ struct Uring
             }
             immutable r = io_uring_enter(payload.fd, len, 0, flags, args);
             if (_expect(r < 0, false)) return -errno;
+            payload.sq.submitted(r);
             return r;
         }
         return 0;
@@ -432,6 +450,7 @@ struct Uring
             }
             immutable r = io_uring_enter(payload.fd, len, want, flags, args);
             if (_expect(r < 0, false)) return -errno;
+            payload.sq.submitted(r);
             return r;
         }
         return wait(want); // just simple wait
@@ -999,6 +1018,7 @@ struct Uring
         immutable r = io_uring_enter(
             payload.fd, len, want, flags, cast(const(sigset_t*))cast(size_t)regIndex);
         if (_expect(r < 0, false)) return -errno;
+        payload.sq.submitted(r);
         return r;
     }
 
@@ -2511,9 +2531,12 @@ struct UringDesc
         // Indirection array of indexes to the sqes array (head and tail are pointing to this array).
         // As we don't need some fancy mappings, just initialize it with constant indexes and forget about it.
         // That way, head and tail are actually indexes to our sqes array.
-        foreach (i; 0..entries)
+        if (!(params.flags & SetupFlags.NO_SQARRAY))
         {
-            *((cast(uint*)(sq.ring + params.sq_off.array)) + i) = i;
+            foreach (i; 0..entries)
+            {
+                *((cast(uint*)(sq.ring + params.sq_off.array)) + i) = i;
+            }
         }
 
         // Each SQE is 64 bytes by default, or 128 bytes if the ring was created with
@@ -2522,6 +2545,8 @@ struct UringDesc
         // requests and must be addressable via the mmap region.
         sq.stride = (params.flags & SetupFlags.SQE128) ? 128 : 64;
         sq.entries = entries;
+        sq.rewind = (params.flags & SetupFlags.SQ_REWIND) != 0;
+        sq.sqeMixed = (params.flags & SetupFlags.SQE_MIXED) != 0;
 
         auto psqes = mmap(
             null, cast(size_t)entries * sq.stride,
@@ -2566,17 +2591,30 @@ struct SubmissionQueue
     void* sqesPtr;
     uint  entries;
     uint  stride; // bytes per SQE slot (64 or 128)
+    bool  rewind;
+    bool  sqeMixed;
 
     uint localTail; // used for batch submission
 
-    uint head() const @safe pure { return atomicLoad!(MemoryOrder.acq)(*khead); }
+    uint head() const @safe pure
+    {
+        return rewind ? 0 : atomicLoad!(MemoryOrder.acq)(*khead);
+    }
+
     uint tail() const @safe pure { return localTail; }
 
     void flushTail() @safe pure
     {
         pragma(inline, true);
+        if (rewind) return;
         // debug printf("SQ updating tail: %d\n", localTail);
         atomicStore!(MemoryOrder.rel)(*ktail, localTail);
+    }
+
+    void submitted(int submitted) @safe pure
+    {
+        pragma(inline, true);
+        if (rewind && submitted > 0) localTail = 0;
     }
 
     SubmissionQueueFlags flags() const @safe pure
@@ -2606,10 +2644,23 @@ struct SubmissionQueue
         return slot(localTail++);
     }
 
+    ref SubmissionEntry next128()() @trusted pure return
+    {
+        if (!sqeMixed) return next();
+
+        auto idx = reserve128Slot();
+        return slot(idx);
+    }
+
     void put()(auto ref SubmissionEntry entry) @trusted pure
     {
-        assert(!full, "SumbissionQueue is full");
-        slot(localTail++) = entry;
+        if (sqeMixed && is128Operation(entry.opcode))
+            slot(reserve128Slot()) = entry;
+        else
+        {
+            assert(!full, "SumbissionQueue is full");
+            slot(localTail++) = entry;
+        }
     }
 
     void put(OP)(auto ref OP op)
@@ -2638,6 +2689,37 @@ struct SubmissionQueue
     }
 
     uint dropped() const @safe pure { return atomicLoad!(MemoryOrder.raw)(*kdropped); }
+
+    private uint reserve128Slot() @trusted pure
+    {
+        assert(sqeMixed, "Ring was not created with SQE_MIXED");
+
+        auto h = head;
+        auto t = localTail;
+        if (((t + 1) & ringMask) == 0)
+        {
+            assert((t + 2) - h < entries, "SumbissionQueue does not have room for wrapped SQE128");
+            auto pad = &slot(t);
+            *pad = SubmissionEntry.init;
+            (*pad).opcode = Operation.NOP;
+            (*pad).fd = -1;
+            (*pad).flags = SubmissionEntryFlags.CQE_SKIP_SUCCESS;
+            localTail = t + 1;
+            t = localTail;
+        }
+        else
+        {
+            assert((t + 1) - h < entries, "SumbissionQueue does not have room for SQE128");
+        }
+
+        localTail = t + 2;
+        return t;
+    }
+}
+
+private bool is128Operation(Operation op) @safe pure nothrow @nogc
+{
+    return op == Operation.NOP128 || op == Operation.URING_CMD128;
 }
 
 struct CompletionQueue

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -1877,6 +1877,60 @@ ref SubmissionEntry prepFutexWaitv(return ref SubmissionEntry entry,
     return entry;
 }
 
+/**
+ * Prepares async `ftruncate(2)` operation (`IORING_OP_FTRUNCATE`). `len` is the desired file
+ * length in bytes.
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepFtruncate(return ref SubmissionEntry entry, int fd, long len) @safe
+{
+    entry.prepRW(Operation.FTRUNCATE, fd, null, 0, len);
+    return entry;
+}
+
+/**
+ * Prepares `IORING_OP_FIXED_FD_INSTALL` — promote a registered direct fd into a real fd in
+ * the process file table. `fd` is the index into the registered-files table (the SQE is
+ * issued with `IOSQE_FIXED_FILE` automatically). On success the new real fd is returned in
+ * the CQE's `res` field.
+ *
+ * `flags` accepts `IORING_FIXED_FD_NO_CLOEXEC` to skip setting `O_CLOEXEC` on the new fd.
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepFixedFdInstall(return ref SubmissionEntry entry,
+    int fd, uint flags = 0) @safe
+{
+    entry.prepRW(Operation.FIXED_FD_INSTALL, fd, null, 0, 0);
+    entry.flags = cast(SubmissionEntryFlags)(entry.flags | SubmissionEntryFlags.FIXED_FILE);
+    entry.install_fd_flags = flags;
+    return entry;
+}
+
+/**
+ * Prepares async `bind(2)` operation (`IORING_OP_BIND`).
+ *
+ * Note: Available from Linux 6.11
+ */
+ref SubmissionEntry prepBind(ADDR)(return ref SubmissionEntry entry,
+    int fd, ref const(ADDR) addr, uint addrlen) @trusted
+{
+    entry.prepRW(Operation.BIND, fd, cast(void*)&addr, 0, addrlen);
+    return entry;
+}
+
+/**
+ * Prepares async `listen(2)` operation (`IORING_OP_LISTEN`).
+ *
+ * Note: Available from Linux 6.11
+ */
+ref SubmissionEntry prepListen(return ref SubmissionEntry entry, int fd, int backlog) @safe
+{
+    entry.prepRW(Operation.LISTEN, fd, null, backlog, 0);
+    return entry;
+}
+
 private:
 
 // uring cleanup

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -779,6 +779,39 @@ struct Uring
         if (_expect(r < 0, false)) return -errno;
         return 0;
     }
+
+    /**
+     * Synchronously cancel one or more in-flight requests matching the keys in `reg`. Returns
+     * the number of cancelled requests on success, `-errno` on failure. Use
+     * `KernelTimespec(-1, -1)` in `reg.timeout` to wait indefinitely.
+     *
+     * Note: Available from Linux 6.0
+     */
+    int registerSyncCancel(scope ref io_uring_sync_cancel_reg reg) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_SYNC_CANCEL, &reg, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return r;
+    }
+
+    /**
+     * Restrict the range of indices within the registered file table that the kernel will use
+     * for direct-fd allocations (e.g. when an SQE has `file_index == IORING_FILE_INDEX_ALLOC`).
+     * Requires a prior `registerFiles[Sparse]` setup.
+     *
+     * Note: Available from Linux 6.0
+     */
+    int registerFileAllocRange(uint off, uint len) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        io_uring_file_index_range range;
+        range.off = off;
+        range.len = len;
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_FILE_ALLOC_RANGE, &range, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
 }
 
 /**
@@ -1781,6 +1814,66 @@ ref SubmissionEntry prepWaitid(return ref SubmissionEntry entry,
     entry.waitid_flags = flags;
     entry.file_index = cast(uint)options;
     entry.addr2 = cast(ulong)cast(void*)infop;
+    return entry;
+}
+
+/**
+ * Prepares async futex wait (`IORING_OP_FUTEX_WAIT`). The request completes when the kernel
+ * wakes the futex via FUTEX_WAKE or when the request is cancelled.
+ *
+ * Params:
+ *      entry = `SubmissionEntry` to prepare
+ *      futex = pointer to the futex word (must remain valid until completion)
+ *      val   = expected value; the wait fails fast with `-EAGAIN` if `*futex != val`
+ *      mask  = bitmask for selective wakes (matches `FUTEX_WAKE` with the same mask). Use
+ *              `~0UL` to wake unconditionally.
+ *      futex2_flags = `FUTEX2_SIZE_*` plus optional `FUTEX2_PRIVATE` / `FUTEX2_NUMA`.
+ *      flags = currently unused, pass 0.
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepFutexWait(return ref SubmissionEntry entry,
+    const(uint)* futex, ulong val, ulong mask, uint futex2_flags, uint flags = 0) @trusted
+{
+    entry.prepRW(Operation.FUTEX_WAIT, cast(int)futex2_flags, cast(void*)futex, 0, val);
+    entry.futex_flags = flags;
+    entry.addr3 = mask;
+    return entry;
+}
+
+/**
+ * Prepares async futex wake (`IORING_OP_FUTEX_WAKE`).
+ *
+ * Params:
+ *      entry = `SubmissionEntry` to prepare
+ *      futex = pointer to the futex word
+ *      val   = number of waiters to wake
+ *      mask  = bitmask to match against waiters. Use `~0UL` to wake any waiter.
+ *      futex2_flags = `FUTEX2_SIZE_*` plus optional `FUTEX2_PRIVATE` / `FUTEX2_NUMA`.
+ *      flags = currently unused, pass 0.
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepFutexWake(return ref SubmissionEntry entry,
+    const(uint)* futex, ulong val, ulong mask, uint futex2_flags, uint flags = 0) @trusted
+{
+    entry.prepRW(Operation.FUTEX_WAKE, cast(int)futex2_flags, cast(void*)futex, 0, val);
+    entry.futex_flags = flags;
+    entry.addr3 = mask;
+    return entry;
+}
+
+/**
+ * Prepares async vectored futex wait (`IORING_OP_FUTEX_WAITV`). The request completes when
+ * any of the `nr_futex` entries is woken.
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepFutexWaitv(return ref SubmissionEntry entry,
+    const(futex_waitv)* futex, uint nr_futex, uint flags = 0) @trusted
+{
+    entry.prepRW(Operation.FUTEX_WAITV, 0, cast(void*)futex, nr_futex, 0);
+    entry.futex_flags = flags;
     return entry;
 }
 

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -855,6 +855,216 @@ struct Uring
         if (_expect(r < 0, false)) return -errno;
         return 0;
     }
+
+    /**
+     * Select the clock source used for ring-side timeouts (e.g. `IORING_OP_TIMEOUT`).
+     * `clockid` is one of the `CLOCK_*` values from `<time.h>`.
+     *
+     * Note: Available from Linux 6.10
+     */
+    int registerClock(uint clockid) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        io_uring_clock_register reg;
+        reg.clockid = clockid;
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_CLOCK, &reg, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Clone the entire registered-buffer table from `src` into this ring (`dst`). The two
+     * rings can be in the same or different processes (passed by ring fd). The destination
+     * ring must not already have buffers registered unless `flags` includes
+     * `IORING_REGISTER_DST_REPLACE`.
+     *
+     * Note: Available from Linux 6.10
+     */
+    int cloneBuffers(ref const Uring src, uint flags = 0) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    in (src.payload !is null, "Source Uring hasn't been initialized")
+    {
+        return cloneBuffersOffset(src, 0, 0, 0, flags);
+    }
+
+    /**
+     * Clone a sub-range of registered buffers from `src`. `nr == 0` is shorthand for "clone
+     * the whole source table starting at `srcOff`".
+     *
+     * Note: Available from Linux 6.10
+     */
+    int cloneBuffersOffset(ref const Uring src, uint dstOff, uint srcOff, uint nr, uint flags) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    in (src.payload !is null, "Source Uring hasn't been initialized")
+    {
+        io_uring_clone_buffers cb;
+        cb.src_fd  = cast(uint)src.payload.fd;
+        cb.flags   = flags & ~IORING_REGISTER_SRC_REGISTERED; // src always passed as a raw fd here
+        cb.src_off = srcOff;
+        cb.dst_off = dstOff;
+        cb.nr      = nr;
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_CLONE_BUFFERS, &cb, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Resize the SQ / CQ of this ring in-place. `newParams.sq_entries` / `cq_entries` set
+     * the new sizes; the kernel preserves in-flight requests across the resize. Internally
+     * unmaps and re-mmaps the rings to point at the kernel's new regions. Fails (with
+     * `-EINVAL`) on rings created with `IORING_SETUP_NO_MMAP`.
+     *
+     * Note: Available from Linux 6.12
+     */
+    int resizeRings(ref SetupParameters newParams) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_RESIZE_RINGS, &newParams, 1);
+        if (_expect(r < 0, false)) return -errno;
+
+        // The kernel atomically swaps the underlying ring memory. Drop the old mappings
+        // (the file descriptor is unchanged) and re-map with the params it just filled in.
+        munmap(payload.sq.sqesPtr, payload.sq.entries * payload.sq.stride);
+        munmap(payload.sq.ring, payload.sq.ringSize);
+        if (payload.cq.ring && payload.cq.ring != payload.sq.ring)
+            munmap(payload.cq.ring, payload.cq.ringSize);
+
+        payload.sq = SubmissionQueue.init;
+        payload.cq = CompletionQueue.init;
+        payload.params = newParams;
+
+        return payload.mapRings();
+    }
+
+    /**
+     * Register a memory region with the kernel. Currently the practical use is the wait-arg
+     * registration path (`IORING_MEM_REGION_REG_WAIT_ARG` in `reg.flags`).
+     *
+     * Note: Available from Linux 6.13
+     */
+    int registerMemRegion(scope ref io_uring_mem_region_reg reg) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_MEM_REGION, &reg, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Register an array of wait-arg entries (`reg`/`nr`). Each slot pre-configures a timeout,
+     * minimum wait, and sigmask that `submitAndWaitReg` (below) can reference by index. The
+     * wait-arg region is exposed via `REGISTER_MEM_REGION` with the `WAIT_ARG` flag set.
+     *
+     * Note: Available from Linux 6.13 — liburing 2.9 stubs its own helper to return `-EINVAL`,
+     * so this wrapper goes through the `MEM_REGION` opcode directly.
+     */
+    int registerWaitReg(io_uring_reg_wait[] reg) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    in (reg.length > 0, "empty wait_reg array")
+    {
+        io_uring_region_desc desc;
+        desc.user_addr   = cast(ulong)cast(void*)reg.ptr;
+        desc.size        = reg.length * io_uring_reg_wait.sizeof;
+        desc.flags       = IORING_MEM_REGION_TYPE_USER;
+
+        io_uring_mem_region_reg mr;
+        mr.region_uptr = cast(ulong)cast(void*)&desc;
+        mr.flags       = IORING_MEM_REGION_REG_WAIT_ARG;
+
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_MEM_REGION, &mr, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Submit pending SQEs and wait for at least `want` CQEs against the wait-arg slot at
+     * `regIndex` (pre-registered via `registerWaitReg`). The wait inherits the timeout,
+     * minimum-wait and sigmask configured in that slot.
+     *
+     * Note: Available from Linux 6.13
+     */
+    int submitAndWaitReg(uint want, int regIndex) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    in (want > 0, "Invalid want value")
+    {
+        immutable len = cast(int)payload.sq.length;
+        if (len > 0) payload.sq.flushTail();
+        EnterFlags flags = EnterFlags.GETEVENTS | EnterFlags.EXT_ARG_REG;
+        if (payload.params.flags & SetupFlags.SQPOLL)
+        {
+            if (payload.sq.flags & SubmissionQueueFlags.NEED_WAKEUP)
+                flags |= EnterFlags.SQ_WAKEUP;
+        }
+        // The "args" pointer is reinterpreted as a wait-arg index in EXT_ARG_REG mode.
+        immutable r = io_uring_enter(
+            payload.fd, len, want, flags, cast(const(sigset_t*))cast(size_t)regIndex);
+        if (_expect(r < 0, false)) return -errno;
+        return r;
+    }
+
+    /**
+     * Submit pending SQEs and wait for at least `want` CQEs with an absolute timeout `ts`
+     * and a minimum wait `minWaitUsec` (the kernel will let through completions arriving
+     * sooner than `ts` once it has waited at least `minWaitUsec` microseconds).
+     *
+     * Note: Available from Linux 6.13
+     */
+    int submitAndWaitMinTimeout(uint want, ref const KernelTimespec ts, uint minWaitUsec,
+        const(sigset_t)* sigmask = null) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    in (want > 0, "Invalid want value")
+    {
+        io_uring_getevents_arg arg;
+        arg.sigmask     = cast(ulong)cast(const(void*))sigmask;
+        arg.sigmask_sz  = sigmask is null ? 0 : sigset_t.sizeof;
+        arg.pad         = minWaitUsec;          // overlays kernel `min_wait_usec`
+        arg.ts          = cast(ulong)cast(const(void*))&ts;
+        return wait!io_uring_getevents_arg(want, &arg);
+    }
+
+    /**
+     * `IORING_REGISTER_SEND_MSG_RING` — synchronously deliver an `IORING_OP_MSG_RING` SQE
+     * to another ring without owning a fully-fledged ring. The provided `sqe` must already
+     * be prepared with `prepMsgRing` (or `prepMsgRingCqeFlags`) targeting the destination
+     * ring fd.
+     *
+     * Note: This is a thin wrapper around `io_uring_register(-1, REGISTER_SEND_MSG_RING, sqe, 1)`
+     * and does NOT require an initialized `Uring`. Available from Linux 6.10.
+     */
+    static int sendMsgRingSync(ref SubmissionEntry sqe) @trusted
+    {
+        immutable r = io_uring_register(-1, RegisterOpCode.REGISTER_SEND_MSG_RING, &sqe, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return r;
+    }
+
+    /**
+     * Register a NIC hardware receive queue for zerocopy receive. Requires a supported NIC
+     * and is hence environment-dependent — the SQE-side counterpart is `IORING_OP_RECV_ZC`.
+     *
+     * Note: Available from Linux 6.11
+     */
+    int registerIfq(scope ref io_uring_zcrx_ifq_reg reg) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_ZCRX_IFQ, &reg, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Install a classic-BPF filter rule that the kernel evaluates before accepting matching
+     * SQEs. `bpf.filter.filter_ptr` points at `sock_filter` instructions.
+     *
+     * Note: Available from Linux 6.16
+     */
+    int registerBpfFilter(scope ref io_uring_bpf bpf) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_BPF_FILTER, &bpf, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
 }
 
 /**

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -812,6 +812,49 @@ struct Uring
         if (_expect(r < 0, false)) return -errno;
         return 0;
     }
+
+    /**
+     * Read the current head index of a provided buffer ring. The caller fills `status.buf_group`
+     * to identify the target ring; on success `status.head` is populated.
+     *
+     * Note: Available from Linux 6.8
+     */
+    int bufRingStatus(scope ref io_uring_buf_status status) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_PBUF_STATUS, &status, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Enable NAPI busy-polling on the ring. `napi.busy_poll_to` is the busy-poll timeout in
+     * microseconds, `napi.prefer_busy_poll` selects busy poll over interrupt-driven receive.
+     * On return, `napi` is filled with the previous configuration.
+     *
+     * Note: Available from Linux 6.9
+     */
+    int registerNapi(scope ref io_uring_napi napi) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_NAPI, &napi, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Disable NAPI busy-polling on the ring. On return, `napi` is filled with the
+     * configuration that was in effect.
+     *
+     * Note: Available from Linux 6.9
+     */
+    int unregisterNapi(scope ref io_uring_napi napi) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.UNREGISTER_NAPI, &napi, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
 }
 
 /**
@@ -1928,6 +1971,40 @@ ref SubmissionEntry prepBind(ADDR)(return ref SubmissionEntry entry,
 ref SubmissionEntry prepListen(return ref SubmissionEntry entry, int fd, int backlog) @safe
 {
     entry.prepRW(Operation.LISTEN, fd, null, backlog, 0);
+    return entry;
+}
+
+/**
+ * Prepares async `epoll_wait(2)` (`IORING_OP_EPOLL_WAIT`). `events` receives up to
+ * `maxEvents` ready events; the CQE's `res` field reports the number of events filled in.
+ *
+ * Note: Available from Linux 6.13
+ */
+ref SubmissionEntry prepEpollWait(return ref SubmissionEntry entry,
+    int epfd, epoll_event[] events, uint flags = 0) @trusted
+{
+    assert(events.length && events.length <= int.max, "events buffer length");
+    entry.prepRW(Operation.EPOLL_WAIT, epfd, cast(void*)events.ptr, cast(uint)events.length, 0);
+    entry.rw_flags = cast(ReadWriteFlags)flags;
+    return entry;
+}
+
+/**
+ * Prepares zero-copy receive (`IORING_OP_RECV_ZC`). The receive uses a pre-registered
+ * interface queue (`registerIfq`, available in a later phase) addressed by `ifqIdx`; the
+ * kernel fills a provided buffer ring with received packet payloads without copying. Returns
+ * one or more CQEs marked with `CQEFlags.MORE` (multishot) or a single CQE without `MORE`
+ * (one-shot).
+ *
+ * Note: Available from Linux 6.13. Requires a configured NIC zerocopy-RX ifq, so this op is
+ * functionally testable only on hosts with a supported network interface.
+ */
+ref SubmissionEntry prepRecvZc(return ref SubmissionEntry entry, int sockfd, uint len,
+    MsgFlags flags, uint ifqIdx) @safe
+{
+    entry.prepRW(Operation.RECV_ZC, sockfd, null, len, 0);
+    entry.msg_flags = flags;
+    entry.zcrx_ifq_idx = ifqIdx;
     return entry;
 }
 

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -2247,7 +2247,7 @@ struct UringDesc
     {
         if (regBuffers) free(cast(void*)&regBuffers[0]);
         if (sq.ring) munmap(sq.ring, sq.ringSize);
-        if (sq.sqes) munmap(cast(void*)&sq.sqes[0], sq.sqes.length * SubmissionEntry.sizeof);
+        if (sq.sqesPtr) munmap(sq.sqesPtr, sq.entries * sq.stride);
         if (cq.ring && cq.ring != sq.ring) munmap(cq.ring, cq.ringSize);
         close(fd);
     }
@@ -2306,14 +2306,21 @@ struct UringDesc
             *((cast(uint*)(sq.ring + params.sq_off.array)) + i) = i;
         }
 
+        // Each SQE is 64 bytes by default, or 128 bytes if the ring was created with
+        // `IORING_SETUP_SQE128`. The standard SubmissionEntry struct is 64 bytes; in SQE128
+        // mode the trailing 64 bytes are reserved for the `cmd[]` payload of URING_CMD128
+        // requests and must be addressable via the mmap region.
+        sq.stride = (params.flags & SetupFlags.SQE128) ? 128 : 64;
+        sq.entries = entries;
+
         auto psqes = mmap(
-            null, entries * SubmissionEntry.sizeof,
+            null, cast(size_t)entries * sq.stride,
             PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE,
             fd, SetupParameters.SUBMISSION_QUEUE_ENTRIES_OFFSET
         );
 
         if (psqes == MAP_FAILED) return -errno;
-        sq.sqes = (cast(SubmissionEntry*)psqes)[0..entries];
+        sq.sqesPtr = psqes;
 
         entries = *cast(uint*)(cq.ring + params.cq_off.ring_entries);
         cq.khead        = cast(uint*)(cq.ring + params.cq_off.head);
@@ -2343,8 +2350,12 @@ struct SubmissionQueue
     void* ring; // pointer to the mmaped region
     size_t ringSize; // size of mmaped memory block
 
-    // mmapped list of entries (fixed length)
-    SubmissionEntry[] sqes;
+    // Raw SQE storage. The stride is 64 for default rings and 128 for `SetupFlags.SQE128`
+    // rings — the kernel always exposes the 64-byte SQE struct at the start of each slot,
+    // and (in SQE128 mode) 64 bytes of trailing `cmd[]` payload for `IORING_OP_URING_CMD128`.
+    void* sqesPtr;
+    uint  entries;
+    uint  stride; // bytes per SQE slot (64 or 128)
 
     uint localTail; // used for batch submission
 
@@ -2363,29 +2374,39 @@ struct SubmissionQueue
         return cast(SubmissionQueueFlags)atomicLoad!(MemoryOrder.raw)(*kflags);
     }
 
-    bool full() const @safe pure { return sqes.length == length; }
+    bool full() const @safe pure { return entries == length; }
 
     size_t length() const @safe pure { return tail - head; }
 
-    size_t capacity() const @safe pure { return sqes.length - length; }
+    size_t capacity() const @safe pure { return entries - length; }
 
-    ref SubmissionEntry next()() @safe pure return
+    /// Return a ref to the slot at `i & ringMask`. Stride-aware: in SQE128 rings, the slot
+    /// covers 128 bytes; the standard SQE fields are in the first 64, the trailing 64 are
+    /// accessible via the `cmd[]` zero-length array on `SubmissionEntry`.
+    pragma(inline, true)
+    ref SubmissionEntry slot(uint i) @system pure return
     {
-        assert(!full, "SumbissionQueue is full");
-        return sqes[localTail++ & ringMask];
+        // `entry-by-byte-offset` to honour the runtime stride.
+        return *cast(SubmissionEntry*)(cast(ubyte*)sqesPtr + cast(size_t)(i & ringMask) * stride);
     }
 
-    void put()(auto ref SubmissionEntry entry) @safe pure
+    ref SubmissionEntry next()() @trusted pure return
     {
         assert(!full, "SumbissionQueue is full");
-        sqes[localTail++ & ringMask] = entry;
+        return slot(localTail++);
+    }
+
+    void put()(auto ref SubmissionEntry entry) @trusted pure
+    {
+        assert(!full, "SumbissionQueue is full");
+        slot(localTail++) = entry;
     }
 
     void put(OP)(auto ref OP op)
         if (!is(OP == SubmissionEntry))
     {
         assert(!full, "SumbissionQueue is full");
-        sqes[localTail++ & ringMask].fill(op);
+        () @trusted { slot(localTail++).fill(op); }();
     }
 
     private void putWith(alias FN, ARGS...)(auto ref ARGS args)
@@ -2399,11 +2420,11 @@ struct SubmissionQueue
             "Alias function must accept at least `ref SubmissionEntry`");
 
         static assert(
-            is(typeof(FN(sqes[localTail & ringMask], args))),
+            is(typeof(FN(slot(localTail), args))),
             "Provided function is not callable with " ~ (Parameters!((ref SubmissionEntry e, ARGS args) {})).stringof);
 
         assert(!full, "SumbissionQueue is full");
-        FN(sqes[localTail++ & ringMask], args);
+        () @trusted { FN(slot(localTail++), args); }();
     }
 
     uint dropped() const @safe pure { return atomicLoad!(MemoryOrder.raw)(*kdropped); }

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -2098,8 +2098,10 @@ ref SubmissionEntry prepWaitid(return ref SubmissionEntry entry,
  *      entry = `SubmissionEntry` to prepare
  *      futex = pointer to the futex word (must remain valid until completion)
  *      val   = expected value; the wait fails fast with `-EAGAIN` if `*futex != val`
- *      mask  = bitmask for selective wakes (matches `FUTEX_WAKE` with the same mask). Use
- *              `~0UL` to wake unconditionally.
+ *      mask  = bitmask for selective wakes (matches `FUTEX_WAKE` with the same mask). The
+ *              value must fit within the size declared by `futex2_flags` — for the common
+ *              `FUTEX2_SIZE_U32` case use `FUTEX_BITSET_MATCH_ANY` (`0xFFFFFFFF`); the kernel
+ *              rejects masks with bits set above the size with `-EINVAL`.
  *      futex2_flags = `FUTEX2_SIZE_*` plus optional `FUTEX2_PRIVATE` / `FUTEX2_NUMA`.
  *      flags = currently unused, pass 0.
  *

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -1692,6 +1692,98 @@ ref SubmissionEntry prepSocket(return ref SubmissionEntry entry,
     return entry;
 }
 
+/**
+ * Prepares zero-copy `send` operation (`IORING_OP_SEND_ZC`).
+ *
+ * Unlike the regular `send` op, this submits a request that will (when possible) bypass the
+ * kernel copy by pinning user pages. Two CQEs are generated per request: the first reports
+ * the transfer result (with `CQEFlags.MORE` set), the second is the zero-copy notification
+ * (`CQEFlags.NOTIF`) emitted once the kernel is done with the pages and the buffer can be
+ * reused. If `IORING_SEND_ZC_REPORT_USAGE` is set in `zc_flags`, the notification's `res`
+ * field will contain `IORING_NOTIF_USAGE_ZC_COPIED` when the kernel had to fall back to a
+ * copy, or `0` otherwise.
+ *
+ * Note: Available from Linux 6.0
+ */
+ref SubmissionEntry prepSendZc(return ref SubmissionEntry entry,
+    int sockfd, const(ubyte)[] buf, MsgFlags flags = MsgFlags.NONE, uint zc_flags = 0) @trusted
+{
+    entry.prepRW(Operation.SEND_ZC, sockfd, cast(void*)buf.ptr, cast(uint)buf.length, 0);
+    entry.msg_flags = flags;
+    entry.ioprio = cast(ushort)zc_flags;
+    return entry;
+}
+
+/**
+ * Prepares zero-copy `send` operation (`IORING_OP_SEND_ZC`) using a registered buffer.
+ *
+ * Note: Available from Linux 6.0
+ */
+ref SubmissionEntry prepSendZcFixed(return ref SubmissionEntry entry,
+    int sockfd, const(ubyte)[] buf, MsgFlags flags, uint zc_flags, ushort bufIndex) @trusted
+{
+    entry.prepSendZc(sockfd, buf, flags, zc_flags);
+    entry.ioprio = cast(ushort)(entry.ioprio | IORING_RECVSEND_FIXED_BUF);
+    entry.buf_index = bufIndex;
+    return entry;
+}
+
+/**
+ * Prepares zero-copy `sendmsg` operation (`IORING_OP_SENDMSG_ZC`). See `prepSendZc` for the
+ * notification semantics.
+ *
+ * Note: Available from Linux 6.1
+ */
+ref SubmissionEntry prepSendmsgZc(return ref SubmissionEntry entry, int fd, ref msghdr msg,
+    MsgFlags flags = MsgFlags.NONE) @trusted
+{
+    entry.prepSendMsg(fd, msg, flags);
+    entry.opcode = Operation.SENDMSG_ZC;
+    return entry;
+}
+
+/**
+ * Prepares multishot `read` operation (`IORING_OP_READ_MULTISHOT`).
+ *
+ * Reads are repeated against the same fd using buffers picked from the provided buffer group
+ * (`bufGroup`). Each successful CQE will set `CQEFlags.BUFFER` and `CQEFlags.MORE` while the
+ * request remains armed. The operation terminates (without `CQEFlags.MORE` set) on EOF, on
+ * error, or if no buffer was available (`-ENOBUFS`).
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepReadMultishot(return ref SubmissionEntry entry,
+    int fd, uint nbytes, long offset, ushort bufGroup) @safe
+{
+    entry.prepRW(Operation.READ_MULTISHOT, fd, null, nbytes, offset);
+    entry.buf_group = bufGroup;
+    entry.flags = SubmissionEntryFlags.BUFFER_SELECT;
+    return entry;
+}
+
+/**
+ * Prepares async `waitid(2)` operation (`IORING_OP_WAITID`).
+ *
+ * Params:
+ *      entry = `SubmissionEntry` to prepare
+ *      idtype = `P_PID`, `P_PGID`, `P_ALL`, or `P_PIDFD`
+ *      id     = pid/pgid/pidfd to wait on (ignored for `P_ALL`)
+ *      infop  = optional `siginfo_t*` to receive child status (may be `null`)
+ *      options = wait options (e.g. `WEXITED | WSTOPPED`)
+ *      flags   = currently unused, pass 0
+ *
+ * Note: Available from Linux 6.5
+ */
+ref SubmissionEntry prepWaitid(return ref SubmissionEntry entry,
+    int idtype, uint id, siginfo_t* infop, int options, uint flags = 0) @trusted
+{
+    entry.prepRW(Operation.WAITID, cast(int)id, null, cast(uint)idtype, 0);
+    entry.waitid_flags = flags;
+    entry.file_index = cast(uint)options;
+    entry.addr2 = cast(ulong)cast(void*)infop;
+    return entry;
+}
+
 private:
 
 // uring cleanup

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -2565,7 +2565,8 @@ struct UringDesc
         cq.ktail        = cast(uint*)(cq.ring + params.cq_off.tail);
         cq.ringMask     = *cast(uint*)(cq.ring + params.cq_off.ring_mask);
         cq.koverflow    = cast(uint*)(cq.ring + params.cq_off.overflow);
-        cq.cqes         = (cast(CompletionEntry*)(cq.ring + params.cq_off.cqes))[0..entries];
+        cq.shift        = (params.flags & SetupFlags.CQE32) ? 1 : 0;
+        cq.cqes         = (cast(CompletionEntry*)(cq.ring + params.cq_off.cqes))[0..entries << cq.shift];
         cq.kflags       = cast(uint*)(cq.ring + params.cq_off.flags);
         return 0;
     }
@@ -2736,6 +2737,7 @@ struct CompletionQueue
     CompletionEntry[] cqes; // array of entries (fixed length)
 
     uint ringMask; // constant mask used to determine array index from head/tail
+    uint shift; // 1 for CQE32 rings, 0 for 16-byte and CQE_MIXED rings
 
     // mmap details (for cleanup)
     void* ring;
@@ -2758,14 +2760,14 @@ struct CompletionQueue
     ref CompletionEntry front() @safe pure return
     {
         assert(!empty, "CompletionQueue is empty");
-        return cqes[localHead & ringMask];
+        return cqes[(localHead & ringMask) << shift];
     }
 
     void popFront() @safe pure
     {
         pragma(inline);
         assert(!empty, "CompletionQueue is empty");
-        localHead++;
+        localHead += cqeSlots(front);
         flushHead();
     }
 
@@ -2775,13 +2777,24 @@ struct CompletionQueue
     ref const(CompletionEntry) peekAt(size_t i) const @safe pure return
     {
         assert(i < length, "peekAt index out of range");
-        return cqes[(localHead + cast(uint)i) & ringMask];
+        uint h = localHead;
+        foreach (_; 0..i)
+        {
+            auto cqe = &cqes[(h & ringMask) << shift];
+            h += cqeSlots(*cqe);
+        }
+        return cqes[(h & ringMask) << shift];
     }
 
     uint overflow() const @safe pure { return atomicLoad!(MemoryOrder.raw)(*koverflow); }
 
     /// Runtime CQ flags - written by the application, shouldn't be modified by the kernel.
     void flags(CQRingFlags flags) @safe pure { atomicStore!(MemoryOrder.raw)(*kflags, flags); }
+}
+
+private uint cqeSlots(ref const CompletionEntry cqe) @safe pure nothrow @nogc
+{
+    return (cqe.flags & CQEFlags.F_32) ? 2 : 1;
 }
 
 // just a helper to use atomicStore more easily with older compilers

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -85,11 +85,11 @@ int setup(ref Uring uring, uint entries, ref const SetupParameters params) @safe
  */
 struct Probe
 {
-    static assert (Operation.max < 64, "Needs to be adjusted");
+    static assert (Operation.max < 128, "Needs to be adjusted");
     private
     {
         io_uring_probe probe;
-        io_uring_probe_op[64] ops;
+        io_uring_probe_op[128] ops;
         int err;
     }
 
@@ -2005,6 +2005,210 @@ ref SubmissionEntry prepRecvZc(return ref SubmissionEntry entry, int sockfd, uin
     entry.prepRW(Operation.RECV_ZC, sockfd, null, len, 0);
     entry.msg_flags = flags;
     entry.zcrx_ifq_idx = ifqIdx;
+    return entry;
+}
+
+/**
+ * Prepares vectored read against a registered buffer (`IORING_OP_READV_FIXED`). Each iovec
+ * must point into the registered buffer identified by `bufIndex`. `rwFlags` accepts the same
+ * bits as `preadv2(2)` (e.g. `RWF_HIPRI`, `RWF_NOWAIT`).
+ *
+ * Note: Available from Linux 6.13
+ */
+ref SubmissionEntry prepReadvFixed(return ref SubmissionEntry entry,
+    int fd, const(iovec)[] iovecs, long offset, ReadWriteFlags rwFlags, ushort bufIndex) @trusted
+{
+    assert(iovecs.length && iovecs.length <= int.max, "iovecs length");
+    entry.prepRW(Operation.READV_FIXED, fd, cast(void*)iovecs.ptr, cast(uint)iovecs.length, offset);
+    entry.rw_flags = rwFlags;
+    entry.buf_index = bufIndex;
+    return entry;
+}
+
+/**
+ * Prepares vectored write against a registered buffer (`IORING_OP_WRITEV_FIXED`). See
+ * `prepReadvFixed` for parameter semantics.
+ *
+ * Note: Available from Linux 6.13
+ */
+ref SubmissionEntry prepWritevFixed(return ref SubmissionEntry entry,
+    int fd, const(iovec)[] iovecs, long offset, ReadWriteFlags rwFlags, ushort bufIndex) @trusted
+{
+    assert(iovecs.length && iovecs.length <= int.max, "iovecs length");
+    entry.prepRW(Operation.WRITEV_FIXED, fd, cast(void*)iovecs.ptr, cast(uint)iovecs.length, offset);
+    entry.rw_flags = rwFlags;
+    entry.buf_index = bufIndex;
+    return entry;
+}
+
+/**
+ * Prepares async `pipe2(2)` (`IORING_OP_PIPE`). `fds[0]` will receive the read end, `fds[1]`
+ * the write end on completion. `pipeFlags` accepts `O_CLOEXEC`, `O_DIRECT`, `O_NONBLOCK` —
+ * same bits as the `flags` argument of `pipe2(2)`.
+ *
+ * Note: Available from Linux 6.14
+ */
+ref SubmissionEntry prepPipe(return ref SubmissionEntry entry,
+    return ref int[2] fds, int pipeFlags = 0) @trusted
+{
+    entry.prepRW(Operation.PIPE, 0, cast(void*)fds.ptr, 0, 0);
+    entry.pipe_flags = cast(uint)pipeFlags;
+    return entry;
+}
+
+/**
+ * Prepares async `pipe2(2)` writing the fds into the registered files table starting at
+ * `fileIndex`. `fileIndex == IORING_FILE_INDEX_ALLOC` asks the kernel to pick two free slots.
+ * The two ends land in consecutive table slots; on completion the CQE `res` reports the
+ * starting slot.
+ *
+ * Note: Available from Linux 6.14
+ */
+ref SubmissionEntry prepPipeDirect(return ref SubmissionEntry entry,
+    return ref int[2] fds, uint fileIndex, int pipeFlags = 0) @trusted
+{
+    entry.prepPipe(fds, pipeFlags);
+    // The kernel encodes "alloc" as the special sentinel; otherwise the value is offset by 1
+    // so that 0 can still mean "no fixed slot". This mirrors upstream io_uring_prep_pipe_direct.
+    entry.file_index = (fileIndex == IORING_FILE_INDEX_ALLOC) ? IORING_FILE_INDEX_ALLOC : (fileIndex + 1);
+    return entry;
+}
+
+/**
+ * Prepares a 128-byte `nop` (`IORING_OP_NOP128`). Only meaningful on rings created with
+ * `SetupFlags.SQE128` — exposes the second-half SQE payload for kernels/code that need to
+ * exercise the SQE128 layout.
+ *
+ * Note: Available from Linux 6.16
+ */
+ref SubmissionEntry prepNop128(return ref SubmissionEntry entry) @safe
+{
+    entry.prepRW(Operation.NOP128, -1, null, 0, 0);
+    return entry;
+}
+
+/**
+ * Prepares a `uring_cmd` (`IORING_OP_URING_CMD`). `cmdOp` is the sub-command (e.g. one of
+ * `SOCKET_URING_OP_*` for socket fds, or a driver-specific value such as
+ * `BLOCK_URING_CMD_DISCARD` for block-device fds).
+ *
+ * The 16-byte command payload should be written into `entry.addr3` etc. by callers (or use
+ * a higher-level helper such as `prepCmdSock`). Use `prepUringCmd128` and `SetupFlags.SQE128`
+ * for commands needing the 80-byte large-SQE payload.
+ *
+ * Note: Available from Linux 5.19
+ */
+ref SubmissionEntry prepUringCmd(return ref SubmissionEntry entry, int fd, uint cmdOp) @safe
+{
+    entry.opcode = Operation.URING_CMD;
+    entry.fd = fd;
+    entry.cmd_op = cmdOp;
+    entry.__pad1 = 0;
+    entry.addr = 0;
+    entry.len = 0;
+    return entry;
+}
+
+/// ditto, but for 128-byte SQEs.
+ref SubmissionEntry prepUringCmd128(return ref SubmissionEntry entry, int fd, uint cmdOp) @safe
+{
+    entry.prepUringCmd(fd, cmdOp);
+    entry.opcode = Operation.URING_CMD128;
+    return entry;
+}
+
+/**
+ * Prepares a socket `uring_cmd` (`SOCKET_URING_OP_GETSOCKOPT` / `SOCKET_URING_OP_SETSOCKOPT`,
+ * etc.). Mirrors `io_uring_prep_cmd_sock`.
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepCmdSock(return ref SubmissionEntry entry, uint cmdOp, int fd,
+    uint level, uint optname, scope void* optval, uint optlen) @trusted
+{
+    entry.prepUringCmd(fd, cmdOp);
+    entry.optval = cast(ulong)optval;
+    entry.optname = optname;
+    entry.optlen = optlen;
+    entry.level = level;
+    return entry;
+}
+
+/**
+ * Prepares `SOCKET_URING_OP_GETSOCKNAME` (`peer = 0`) or `SOCKET_URING_OP_GETPEERNAME`
+ * (`peer = 1`). The socket name is written to `*sockaddr_len` bytes of `*sockaddr`; on
+ * completion `*sockaddr_len` is updated.
+ *
+ * Note: Available from Linux 6.7
+ */
+ref SubmissionEntry prepCmdGetsockname(return ref SubmissionEntry entry, int fd,
+    sockaddr* sockaddr_, socklen_t* sockaddr_len, int peer) @trusted
+{
+    entry.prepUringCmd(fd, SOCKET_URING_OP_GETSOCKNAME);
+    entry.addr = cast(ulong)sockaddr_;
+    entry.addr3 = cast(ulong)sockaddr_len;
+    entry.optlen = cast(uint)peer;
+    return entry;
+}
+
+/**
+ * Prepares `BLOCK_URING_CMD_DISCARD` (`IORING_OP_URING_CMD` over a block device fd). Issues
+ * an asynchronous discard of `nbytes` bytes starting at `offset`.
+ *
+ * Note: Available from Linux 6.10
+ */
+ref SubmissionEntry prepCmdDiscard(return ref SubmissionEntry entry, int fd,
+    ulong offset, ulong nbytes) @safe
+{
+    entry.prepUringCmd(fd, BLOCK_URING_CMD_DISCARD);
+    entry.addr = offset;
+    entry.addr3 = nbytes;
+    return entry;
+}
+
+/**
+ * Prepares `IORING_OP_MSG_RING` with `IORING_MSG_RING_FLAGS_PASS` so the receiving ring
+ * observes the requested `cqeFlags` on the target CQE. Mirrors `io_uring_prep_msg_ring_cqe_flags`.
+ *
+ * Note: Available from Linux 6.3
+ */
+ref SubmissionEntry prepMsgRingCqeFlags(return ref SubmissionEntry entry,
+    int fd, uint len, ulong data, uint flags, uint cqeFlags) @safe
+{
+    entry.prepRW(Operation.MSG_RING, fd, null, len, data);
+    entry.msg_ring_flags = IORING_MSG_RING_FLAGS_PASS | flags;
+    entry.file_index = cqeFlags;
+    return entry;
+}
+
+/**
+ * Prepares a bundled send (`IORING_OP_SEND` with `IORING_RECVSEND_BUNDLE`). Bundles fan out
+ * over the provided buffer ring identified by `bufGroup`: the kernel will send as much data
+ * as the ring has available in one submission, generating one CQE per buffer consumed.
+ *
+ * Note: Available from Linux 6.10
+ */
+ref SubmissionEntry prepSendBundle(return ref SubmissionEntry entry,
+    int sockfd, MsgFlags flags, ushort bufGroup) @safe
+{
+    entry.prepSend(sockfd, null, flags);
+    entry.ioprio = cast(ushort)(entry.ioprio | IORING_RECVSEND_BUNDLE);
+    entry.flags = cast(SubmissionEntryFlags)(entry.flags | SubmissionEntryFlags.BUFFER_SELECT);
+    entry.buf_group = bufGroup;
+    return entry;
+}
+
+/**
+ * Attach a destination address to a previously-prepared `prepSend` SQE — turns it into the
+ * equivalent of `sendto(2)`. Useful for `SOCK_DGRAM` sockets.
+ *
+ * Note: Available from Linux 6.10
+ */
+ref SubmissionEntry prepSendSetAddr(ADDR)(return ref SubmissionEntry entry,
+    ref const ADDR dest, ushort addrLen) @trusted
+{
+    entry.addr2 = cast(ulong)cast(void*)&dest;
+    entry.addr_len = addrLen;
     return entry;
 }
 

--- a/tests/api.d
+++ b/tests/api.d
@@ -3,6 +3,7 @@ module tests.api;
 import during;
 import tests.base;
 
+import core.sys.linux.errno;
 version (D_Exceptions) import std.exception : assertThrown;
 import std.range;
 
@@ -244,3 +245,45 @@ unittest
 //     version (D_BetterC) errmsg = "Not implemented";
 //     else throw new Exception("Not implemented");
 // }
+
+// resizeRings grows then shrinks the ring; a NOP round-trip after each resize confirms
+// the SQ/CQ memory and our cached pointers are in sync with the kernel's new layout.
+@("resizeRings grows and shrinks")
+unittest
+{
+    if (!checkKernelVersion(6, 12)) return;
+
+    Uring io;
+    auto rs = io.setup(8);
+    assert(rs >= 0);
+
+    static void nopRoundTrip(ref Uring io, ulong tag)
+    {
+        io.putWith!(
+            (ref SubmissionEntry e, ulong t) { e.prepNop(); e.user_data = t; })(tag);
+        auto sret = io.submit(1);
+        assert(sret == 1);
+        auto cqe = io.front;
+        assert(cqe.user_data == tag);
+        assert(cqe.res == 0);
+        io.popFront();
+    }
+    nopRoundTrip(io, 1);
+
+    // Grow to 32 SQEs / 64 CQEs.
+    SetupParameters bigger;
+    bigger.sq_entries = 32;
+    bigger.cq_entries = 64;
+    auto rg = io.resizeRings(bigger);
+    if (rg == -EINVAL || rg == -EOPNOTSUPP) return;
+    assert(rg == 0, "resizeRings grow");
+    nopRoundTrip(io, 2);
+
+    // Shrink back.
+    SetupParameters smaller;
+    smaller.sq_entries = 4;
+    smaller.cq_entries = 8;
+    auto rsh = io.resizeRings(smaller);
+    assert(rsh == 0, "resizeRings shrink");
+    nopRoundTrip(io, 3);
+}

--- a/tests/api.d
+++ b/tests/api.d
@@ -309,3 +309,67 @@ unittest
     assert(cqe.res == 0);
     assert(cqe.user_data == 7);
 }
+
+@("no_mmap setup is rejected by wrapper")
+unittest
+{
+    if (!checkKernelVersion(6, 5)) return;
+
+    SetupParameters params;
+    params.flags = SetupFlags.NO_MMAP;
+
+    Uring io;
+    auto res = io.setup(4, params);
+    assert(res == -EINVAL, "NO_MMAP requires caller-owned ring memory, which this wrapper does not expose");
+
+    params.flags = SetupFlags.NO_MMAP | SetupFlags.REGISTERED_FD_ONLY;
+    Uring io2;
+    res = io2.setup(4, params);
+    assert(res == -EINVAL, "REGISTERED_FD_ONLY depends on the unsupported NO_MMAP path");
+}
+
+@("no_sqarray NOP round-trip")
+unittest
+{
+    if (!checkKernelVersion(6, 6)) return;
+
+    Uring io;
+    auto res = io.setup(4, SetupFlags.NO_SQARRAY);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "setup(NO_SQARRAY)");
+
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.user_data = 1; });
+    auto sret = io.submit(1);
+    assert(sret == 1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    assert(cqe.res == 0);
+    assert(cqe.user_data == 1);
+}
+
+@("sq_rewind submits fresh entries from slot zero")
+unittest
+{
+    if (!checkKernelVersion(6, 18)) return;
+
+    Uring io;
+    auto res = io.setup(4, SetupFlags.NO_SQARRAY | SetupFlags.SQ_REWIND);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "setup(SQ_REWIND)");
+
+    foreach (tag; 1UL .. 3UL)
+    {
+        io.putWith!(
+            (ref SubmissionEntry e, ulong t)
+            {
+                e.prepNop();
+                e.user_data = t;
+            })(tag);
+        auto sret = io.submit(1);
+        assert(sret == 1);
+        auto cqe = io.front;
+        assert(cqe.res == 0);
+        assert(cqe.user_data == tag);
+        io.popFront();
+    }
+}

--- a/tests/api.d
+++ b/tests/api.d
@@ -288,6 +288,39 @@ unittest
     nopRoundTrip(io, 3);
 }
 
+// `IORING_NOP_INJECT_RESULT`: the kernel sets `cqe.res` to the value the caller passed in
+// `sqe.len`. Lets test code drive arbitrary error codes through the completion path. Linux
+// 6.13+.
+@("nop inject_result drives custom cqe.res")
+unittest
+{
+    if (!checkKernelVersion(6, 13)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0);
+
+    enum INJECTED = 1234;
+    io.putWith!(
+        (ref SubmissionEntry e)
+        {
+            e.prepNop();
+            e.nop_flags = IORING_NOP_INJECT_RESULT;
+            e.len = INJECTED;
+            e.user_data = 1;
+        });
+    auto sret = io.submit(0);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return; // older kernel without NOP flag support
+    assert(cqe.res == INJECTED, "INJECT_RESULT should surface sqe.len in cqe.res");
+    assert(cqe.user_data == 1);
+}
+
 // A NOP round-trip on a ring with SINGLE_ISSUER + DEFER_TASKRUN — confirms the flags reach
 // the kernel correctly and don't break the basic submit/wait path. The combo is documented
 // as requiring SINGLE_ISSUER for DEFER_TASKRUN to take effect.

--- a/tests/api.d
+++ b/tests/api.d
@@ -287,3 +287,25 @@ unittest
     assert(rsh == 0, "resizeRings shrink");
     nopRoundTrip(io, 3);
 }
+
+// A NOP round-trip on a ring with SINGLE_ISSUER + DEFER_TASKRUN — confirms the flags reach
+// the kernel correctly and don't break the basic submit/wait path. The combo is documented
+// as requiring SINGLE_ISSUER for DEFER_TASKRUN to take effect.
+@("single_issuer + defer_taskrun NOP round-trip")
+unittest
+{
+    if (!checkKernelVersion(6, 1)) return;
+
+    Uring io;
+    auto res = io.setup(4, SetupFlags.SINGLE_ISSUER | SetupFlags.DEFER_TASKRUN);
+    if (res == -EINVAL) return; // kernel without DEFER_TASKRUN — bail.
+    assert(res >= 0, "setup with SINGLE_ISSUER | DEFER_TASKRUN");
+
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.user_data = 7; });
+    auto sret = io.submit(1);
+    assert(sret == 1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    assert(cqe.res == 0);
+    assert(cqe.user_data == 7);
+}

--- a/tests/api.d
+++ b/tests/api.d
@@ -406,3 +406,47 @@ unittest
         io.popFront();
     }
 }
+
+@("cqe_mixed advances over 32-byte CQEs")
+unittest
+{
+    if (!checkKernelVersion(6, 18)) return;
+
+    Uring io;
+    auto res = io.setup(4, SetupFlags.CQE_MIXED);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "setup(CQE_MIXED)");
+
+    io.putWith!((ref SubmissionEntry e)
+    {
+        e.prepNop();
+        e.nop_flags = IORING_NOP_CQE32;
+        e.user_data = 1;
+    });
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    auto cqe = io.front;
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+    {
+        io.popFront();
+        return;
+    }
+    assert(cqe.res == 0);
+    assert(cqe.user_data == 1);
+    assert((cqe.flags & CQEFlags.F_32) != 0, "expected 32-byte CQE marker");
+    io.popFront();
+    assert(io.empty, "popFront must advance past both slots of a 32-byte CQE");
+
+    io.putWith!((ref SubmissionEntry e)
+    {
+        e.prepNop();
+        e.user_data = 2;
+    });
+    sret = io.submit(1);
+    assert(sret == 1);
+    cqe = io.front;
+    scope (exit) io.popFront();
+    assert(cqe.res == 0);
+    assert(cqe.user_data == 2);
+}

--- a/tests/epoll_wait.d
+++ b/tests/epoll_wait.d
@@ -1,0 +1,61 @@
+module tests.epoll_wait;
+
+import during;
+import tests.base;
+
+import core.sys.linux.epoll;
+import core.sys.linux.errno;
+import core.sys.posix.unistd : close, pipe, write;
+
+// Functional EPOLL_WAIT round-trip: build an epoll fd watching the read end of a pipe, write
+// to the pipe, then submit IORING_OP_EPOLL_WAIT and assert it reports the pipe fd as ready.
+@("epoll_wait reports ready pipe")
+unittest
+{
+    if (!checkKernelVersion(6, 13)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    int[2] p;
+    auto pr = pipe(p);
+    assert(pr == 0, "pipe()");
+    scope (exit) { close(p[0]); close(p[1]); }
+
+    int ep = epoll_create1(0);
+    assert(ep >= 0, "epoll_create1()");
+    scope (exit) close(ep);
+
+    epoll_event ev;
+    ev.events = EPOLLIN;
+    ev.data.fd = p[0];
+    auto eret = epoll_ctl(ep, EPOLL_CTL_ADD, p[0], &ev);
+    assert(eret == 0, "epoll_ctl(ADD)");
+
+    // Make the pipe readable before submitting the wait, so the kernel can complete the SQE
+    // immediately and we don't have to coordinate with a separate writer thread.
+    ubyte one = 0xaa;
+    auto w = write(p[1], &one, 1);
+    assert(w == 1);
+
+    epoll_event[4] out_;
+    io.putWith!(
+        (ref SubmissionEntry e, int epfd, epoll_event[] dst)
+        {
+            e.prepEpollWait(epfd, dst, 0);
+            e.user_data = 1;
+        })(ep, out_[]);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res == 1, "EPOLL_WAIT should report 1 ready fd");
+    assert(out_[0].data.fd == p[0]);
+    assert((out_[0].events & EPOLLIN) != 0);
+}

--- a/tests/fixed_fd.d
+++ b/tests/fixed_fd.d
@@ -1,0 +1,123 @@
+module tests.fixed_fd;
+
+import during;
+import tests.base;
+
+import core.sys.linux.errno;
+import core.sys.linux.fcntl;
+import core.sys.posix.sys.stat : fstat, stat_t;
+import core.sys.posix.unistd : close, ftruncate, unlink, write;
+
+// FTRUNCATE: shrink a regular file via io_uring and verify the on-disk size changed.
+@("ftruncate regular file")
+unittest
+{
+    if (!checkKernelVersion(6, 9)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    auto fname = getTestFileName!"ftruncate_test";
+    auto fd = openFile(fname, O_CREAT | O_RDWR);
+    scope (exit) { close(fd); unlink(&fname[0]); }
+
+    ubyte[256] data;
+    foreach (i, ref b; data) b = cast(ubyte)i;
+    auto w = write(fd, &data[0], data.length);
+    assert(w == data.length);
+
+    io.putWith!(
+        (ref SubmissionEntry e, int f)
+        {
+            e.prepFtruncate(f, 64);
+            e.user_data = 1;
+        })(fd);
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res == 0, "FTRUNCATE failed");
+
+    stat_t st;
+    auto sr = fstat(fd, &st);
+    assert(sr == 0);
+    assert(st.st_size == 64, "file should have been truncated to 64 bytes");
+}
+
+// FIXED_FD_INSTALL: open a file into the registered-files table via OPENAT_DIRECT, then
+// install it as a real fd via FIXED_FD_INSTALL. Verify the returned fd works by reading
+// through it with a regular libc read().
+@("fixed_fd_install promotes direct fd to real fd")
+unittest
+{
+    if (!checkKernelVersion(6, 7)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    // Reserve a single sparse slot in the files table.
+    int[1] sparse = -1;
+    auto rr = io.registerFiles(sparse[]);
+    if (rr != 0) return;
+    scope (exit) io.unregisterFiles();
+
+    auto fname = getTestFileName!"fixed_fd_install_test";
+    {
+        auto fd = openFile(fname, O_CREAT | O_WRONLY);
+        ubyte[8] data = [10,20,30,40,50,60,70,80];
+        write(fd, &data[0], data.length);
+        close(fd);
+    }
+    scope (exit) unlink(&fname[0]);
+
+    // OPENAT_DIRECT into slot 0.
+    io.putWith!(
+        (ref SubmissionEntry e, char* path)
+        {
+            e.prepOpenatDirect(AT_FDCWD, path, O_RDONLY, 0, 0);
+            e.user_data = 1;
+        })(&fname[0]);
+    auto sret = io.submit(1);
+    assert(sret == 1);
+    io.wait(1);
+    auto cqe = io.front;
+    if (cqe.res < 0)
+    {
+        io.popFront();
+        return; // OPENAT_DIRECT not supported — bail.
+    }
+    assert(cqe.res == 0, "OPENAT_DIRECT failed");
+    io.popFront();
+
+    // FIXED_FD_INSTALL slot 0 → real fd.
+    io.putWith!(
+        (ref SubmissionEntry e)
+        {
+            e.prepFixedFdInstall(0, 0);
+            e.user_data = 2;
+        })();
+    sret = io.submit(1);
+    assert(sret == 1);
+    io.wait(1);
+    cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res >= 0, "FIXED_FD_INSTALL failed");
+
+    int newFd = cqe.res;
+    scope (exit) close(newFd);
+
+    import core.sys.posix.unistd : read;
+    ubyte[8] readBuf;
+    auto rd = read(newFd, &readBuf[0], readBuf.length);
+    assert(rd == 8, "real fd from FIXED_FD_INSTALL should be readable");
+    ubyte[8] expected = [10,20,30,40,50,60,70,80];
+    assert(readBuf[] == expected[]);
+}

--- a/tests/futex.d
+++ b/tests/futex.d
@@ -1,0 +1,144 @@
+module tests.futex;
+
+import during;
+import tests.base;
+
+import core.sys.linux.errno;
+
+// FUTEX_WAIT with mismatched value: the kernel returns -EAGAIN immediately without arming a
+// real wait. This validates the SQE encoding (opcode, addr, val, futex_flags) end-to-end
+// without depending on a wake that races against arming.
+@("futex_wait mismatched value returns -EAGAIN")
+unittest
+{
+    if (!checkKernelVersion(6, 7)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    uint word = 42;
+    io.putWith!(
+        (ref SubmissionEntry e, uint* w)
+        {
+            // Expect 0, but the word holds 42 — wait fails fast with EAGAIN.
+            e.prepFutexWait(w, 0, ~0UL, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+            e.user_data = 1;
+        })(&word);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return; // op not present on this kernel
+    assert(cqe.res == -EAGAIN, "expected -EAGAIN for mismatched FUTEX_WAIT value");
+}
+
+// FUTEX_WAKE on a word with no waiters: succeeds and returns 0 (wake-count). Validates the
+// FUTEX_WAKE SQE encoding without any synchronization complications.
+@("futex_wake with no waiters returns 0")
+unittest
+{
+    if (!checkKernelVersion(6, 7)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    uint word = 0;
+    io.putWith!(
+        (ref SubmissionEntry e, uint* w)
+        {
+            e.prepFutexWake(w, 1, ~0UL, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+            e.user_data = 1;
+        })(&word);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res == 0, "expected wake-count 0 when no waiters present");
+}
+
+@("futex_waitv mismatched value returns -EAGAIN")
+unittest
+{
+    if (!checkKernelVersion(6, 7)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    uint word = 99;
+    futex_waitv[1] vec;
+    vec[0].val = 0;                                 // expected
+    vec[0].uaddr = cast(ulong)&word;                // actually holds 99
+    vec[0].flags = FUTEX2_SIZE_U32 | FUTEX2_PRIVATE;
+
+    io.putWith!(
+        (ref SubmissionEntry e, futex_waitv* v)
+        {
+            e.prepFutexWaitv(v, 1, 0);
+            e.user_data = 1;
+        })(&vec[0]);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res == -EAGAIN, "expected -EAGAIN for mismatched FUTEX_WAITV value");
+}
+
+@("registerFileAllocRange")
+unittest
+{
+    if (!checkKernelVersion(6, 0)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    // Need a sparse registered-files table first.
+    int[8] sparse = -1;
+    auto rr = io.registerFiles(sparse[]);
+    if (rr != 0) return; // older kernel lacking sparse registration — skip.
+
+    auto fr = io.registerFileAllocRange(2, 4);
+    assert(fr == 0 || fr == -EINVAL, "registerFileAllocRange");
+
+    io.unregisterFiles();
+}
+
+@("registerSyncCancel no-match")
+unittest
+{
+    if (!checkKernelVersion(6, 0)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    io_uring_sync_cancel_reg reg;
+    reg.fd = -1;
+    reg.flags = 0;
+    reg.opcode = cast(ubyte)Operation.NOP;
+    reg.timeout.tv_sec = 0;
+    reg.timeout.tv_nsec = 0;
+    reg.addr = 0xdeadbeef;
+
+    // Nothing in flight that matches — kernel should report no matches (-ENOENT) rather
+    // than rejecting the request itself.
+    auto r = io.registerSyncCancel(reg);
+    assert(r == -ENOENT || r == 0, "registerSyncCancel result");
+}

--- a/tests/futex.d
+++ b/tests/futex.d
@@ -3,7 +3,6 @@ module tests.futex;
 import during;
 import tests.base;
 
-import core.stdc.stdio : printf;
 import core.sys.linux.errno;
 import core.sys.posix.pthread;
 import core.sys.posix.unistd : close, pipe, usleep;
@@ -38,7 +37,7 @@ unittest
     io.putWith!(
         (ref SubmissionEntry e, uint* w)
         {
-            e.prepFutexWait(w, 0, ~0UL, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+            e.prepFutexWait(w, 0, FUTEX_BITSET_MATCH_ANY, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
             e.user_data = 1;
         })(&word);
 
@@ -68,7 +67,7 @@ unittest
     io.putWith!(
         (ref SubmissionEntry e, uint* w)
         {
-            e.prepFutexWake(w, 1, ~0UL, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+            e.prepFutexWake(w, 1, FUTEX_BITSET_MATCH_ANY, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
             e.user_data = 1;
         })(&word);
 
@@ -163,7 +162,7 @@ unittest
     io.putWith!(
         (ref SubmissionEntry e, uint* w)
         {
-            e.prepFutexWait(w, 0, ~0UL, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+            e.prepFutexWait(w, 0, FUTEX_BITSET_MATCH_ANY, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
             e.user_data = 1;
         })(&word);
 
@@ -180,7 +179,7 @@ unittest
     atomicStore!(MemoryOrder.rel)(ctx.stop, 1);
     pthread_join(tid, null);
 
-    if (gotRes == -EINVAL || gotRes == -EOPNOTSUPP)
+    if (gotRes == -EOPNOTSUPP)
         return; // op not present on this kernel.
     assert(gotRes == 0, "FUTEX_WAIT was not woken by helper thread");
     assert(ctx.attempts >= 1, "helper made no wake attempts");

--- a/tests/futex.d
+++ b/tests/futex.d
@@ -3,11 +3,28 @@ module tests.futex;
 import during;
 import tests.base;
 
+import core.stdc.stdio : printf;
 import core.sys.linux.errno;
+import core.sys.posix.pthread;
+import core.sys.posix.unistd : close, pipe, usleep;
+
+// SYS_futex (legacy) is universally available on Linux. The kernel's io_uring FUTEX_WAIT and
+// the legacy futex(2) FUTEX_WAIT/WAKE share the same hash bucket for matching `uaddr`s, so a
+// FUTEX_WAKE_PRIVATE issued from a helper thread can wake an io_uring FUTEX2 waiter that was
+// armed with FUTEX2_SIZE_U32 | FUTEX2_PRIVATE on the same address.
+version (X86_64) private enum SYS_futex = 202;
+else version (X86) private enum SYS_futex = 240;
+else version (AArch64) private enum SYS_futex = 98;
+else static assert(0, "Unsupported platform");
+
+private enum FUTEX_WAKE         = 1;
+private enum FUTEX_PRIVATE_FLAG = 128;
+private enum FUTEX_WAKE_PRIVATE = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
+
+private extern (C) int syscall(int sysno, ...) nothrow @nogc @system;
 
 // FUTEX_WAIT with mismatched value: the kernel returns -EAGAIN immediately without arming a
-// real wait. This validates the SQE encoding (opcode, addr, val, futex_flags) end-to-end
-// without depending on a wake that races against arming.
+// real wait. Validates SQE encoding (opcode, addr, val, futex_flags) without racing the wake.
 @("futex_wait mismatched value returns -EAGAIN")
 unittest
 {
@@ -21,7 +38,6 @@ unittest
     io.putWith!(
         (ref SubmissionEntry e, uint* w)
         {
-            // Expect 0, but the word holds 42 — wait fails fast with EAGAIN.
             e.prepFutexWait(w, 0, ~0UL, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
             e.user_data = 1;
         })(&word);
@@ -33,12 +49,12 @@ unittest
     auto cqe = io.front;
     scope (exit) io.popFront();
     if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
-        return; // op not present on this kernel
+        return;
     assert(cqe.res == -EAGAIN, "expected -EAGAIN for mismatched FUTEX_WAIT value");
 }
 
-// FUTEX_WAKE on a word with no waiters: succeeds and returns 0 (wake-count). Validates the
-// FUTEX_WAKE SQE encoding without any synchronization complications.
+// FUTEX_WAKE on a word with no waiters: succeeds and returns 0. Validates the FUTEX_WAKE SQE
+// encoding without synchronization concerns.
 @("futex_wake with no waiters returns 0")
 unittest
 {
@@ -78,8 +94,8 @@ unittest
 
     uint word = 99;
     futex_waitv[1] vec;
-    vec[0].val = 0;                                 // expected
-    vec[0].uaddr = cast(ulong)&word;                // actually holds 99
+    vec[0].val = 0;
+    vec[0].uaddr = cast(ulong)&word;
     vec[0].flags = FUTEX2_SIZE_U32 | FUTEX2_PRIVATE;
 
     io.putWith!(
@@ -100,6 +116,76 @@ unittest
     assert(cqe.res == -EAGAIN, "expected -EAGAIN for mismatched FUTEX_WAITV value");
 }
 
+// End-to-end FUTEX_WAIT / wake handshake: main thread submits an io_uring FUTEX_WAIT, a
+// helper thread issues a legacy FUTEX_WAKE_PRIVATE via syscall to wake it. The helper retries
+// every 5ms to defeat the inherent race between SQE submission and the kernel parking the
+// waiter; it bounds the total wake attempts so a misbehaving kernel can't hang the test.
+private struct WakeCtx
+{
+    uint*               word;
+    shared int          stop;   // set by main thread when CQE has arrived
+    int                 attempts;
+}
+
+private extern (C) void* wakeWorker(void* arg) @system nothrow @nogc
+{
+    auto ctx = cast(WakeCtx*)arg;
+    for (int i = 0; i < 200; i++) // up to ~1s of attempts
+    {
+        // Re-check before sleeping so we exit promptly once main signals stop.
+        import core.atomic : atomicLoad, MemoryOrder;
+        if (atomicLoad!(MemoryOrder.acq)(ctx.stop)) break;
+        usleep(5_000); // 5ms
+        ctx.attempts = i + 1;
+        // Wake one waiter; arg2=val=1 means "wake at most 1 waiter".
+        syscall(SYS_futex, cast(void*)ctx.word, FUTEX_WAKE_PRIVATE, 1, null, null, 0);
+    }
+    return null;
+}
+
+@("futex_wait woken by helper thread")
+unittest
+{
+    if (!checkKernelVersion(6, 7)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    uint word = 0; // matches the val=0 passed to FUTEX_WAIT — wait will arm.
+    WakeCtx ctx;
+    ctx.word = &word;
+
+    pthread_t tid;
+    auto pr = pthread_create(&tid, null, &wakeWorker, &ctx);
+    assert(pr == 0, "pthread_create()");
+
+    io.putWith!(
+        (ref SubmissionEntry e, uint* w)
+        {
+            e.prepFutexWait(w, 0, ~0UL, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+            e.user_data = 1;
+        })(&word);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    int gotRes = cqe.res;
+    io.popFront();
+
+    // Signal helper to stop, then join.
+    import core.atomic : atomicStore, MemoryOrder;
+    atomicStore!(MemoryOrder.rel)(ctx.stop, 1);
+    pthread_join(tid, null);
+
+    if (gotRes == -EINVAL || gotRes == -EOPNOTSUPP)
+        return; // op not present on this kernel.
+    assert(gotRes == 0, "FUTEX_WAIT was not woken by helper thread");
+    assert(ctx.attempts >= 1, "helper made no wake attempts");
+}
+
 @("registerFileAllocRange")
 unittest
 {
@@ -109,10 +195,9 @@ unittest
     auto res = io.setup();
     assert(res >= 0, "Error initializing IO");
 
-    // Need a sparse registered-files table first.
     int[8] sparse = -1;
     auto rr = io.registerFiles(sparse[]);
-    if (rr != 0) return; // older kernel lacking sparse registration — skip.
+    if (rr != 0) return;
 
     auto fr = io.registerFileAllocRange(2, 4);
     assert(fr == 0 || fr == -EINVAL, "registerFileAllocRange");
@@ -137,8 +222,62 @@ unittest
     reg.timeout.tv_nsec = 0;
     reg.addr = 0xdeadbeef;
 
-    // Nothing in flight that matches — kernel should report no matches (-ENOENT) rather
-    // than rejecting the request itself.
     auto r = io.registerSyncCancel(reg);
     assert(r == -ENOENT || r == 0, "registerSyncCancel result");
+}
+
+// Full sync_cancel round-trip: submit a blocking pipe read with a known user_data, then
+// register_sync_cancel matching on that user_data. The cancel call must report at least one
+// match, and the original op's CQE must come back with a negative `res` (-ECANCELED or -EINTR).
+@("registerSyncCancel cancels matching read")
+unittest
+{
+    if (!checkKernelVersion(6, 0)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    int[2] fds;
+    auto pr = pipe(fds);
+    assert(pr == 0, "pipe()");
+    scope (exit) { close(fds[0]); close(fds[1]); }
+
+    enum DATA = 0xCAFEBABE;
+    ubyte[32] buf;
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd, ubyte[] b)
+        {
+            e.prepRead(fd, b, 0);
+            e.user_data = DATA;
+            // Force the request through io-wq so it is genuinely parked when we try to cancel.
+            e.flags = cast(SubmissionEntryFlags)(e.flags | SubmissionEntryFlags.ASYNC);
+        })(fds[0], buf[]);
+
+    auto sret = io.submit(0);
+    assert(sret == 1);
+
+    // Give io-wq a moment to pick the request up.
+    usleep(20_000);
+
+    io_uring_sync_cancel_reg reg;
+    reg.fd = -1;
+    reg.flags = 0;                  // match by user_data (default)
+    reg.opcode = 0;
+    reg.timeout.tv_sec = 5;
+    reg.timeout.tv_nsec = 0;
+    reg.addr = DATA;
+
+    auto cret = io.registerSyncCancel(reg);
+    if (cret == -EINVAL || cret == -ENOSYS)
+        return; // op not present on this kernel — bail.
+    assert(cret >= 0, "sync_cancel failed");
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    assert(cqe.user_data == DATA);
+    assert(cqe.res == -ECANCELED || cqe.res == -EINTR,
+        "cancelled read should report -ECANCELED or -EINTR");
 }

--- a/tests/package.d
+++ b/tests/package.d
@@ -5,6 +5,7 @@ version (D_BetterC)
     import tests.api;
     import tests.base;
     import tests.cancel;
+    import tests.epoll_wait;
     import tests.fixed_fd;
     import tests.fsync;
     import tests.futex;
@@ -23,6 +24,7 @@ version (D_BetterC)
     {
         runTests!("API tests", tests.api);
         runTests!("Cancel tests", tests.cancel);
+        runTests!("Epoll-wait tests", tests.epoll_wait);
         runTests!("Fixed-fd tests", tests.fixed_fd);
         runTests!("Fsync tests", tests.fsync);
         runTests!("Futex tests", tests.futex);

--- a/tests/package.d
+++ b/tests/package.d
@@ -18,6 +18,7 @@ version (D_BetterC)
     import tests.sqe128;
     import tests.thread;
     import tests.timeout;
+    import tests.wait_reg;
     import tests.waitid;
     import tests.zerocopy;
 
@@ -39,6 +40,7 @@ version (D_BetterC)
         runTests!("SQE128 tests", tests.sqe128);
         runTests!("Thread tests", tests.thread);
         runTests!("Timeout tests", tests.timeout);
+        runTests!("Wait-reg tests", tests.wait_reg);
         runTests!("Waitid tests", tests.waitid);
         runTests!("Zerocopy tests", tests.zerocopy);
         printf("All unit tests have been run successfully.\n");

--- a/tests/package.d
+++ b/tests/package.d
@@ -5,6 +5,7 @@ version (D_BetterC)
     import tests.api;
     import tests.base;
     import tests.cancel;
+    import tests.fixed_fd;
     import tests.fsync;
     import tests.futex;
     import tests.msg;
@@ -22,6 +23,7 @@ version (D_BetterC)
     {
         runTests!("API tests", tests.api);
         runTests!("Cancel tests", tests.cancel);
+        runTests!("Fixed-fd tests", tests.fixed_fd);
         runTests!("Fsync tests", tests.fsync);
         runTests!("Futex tests", tests.futex);
         runTests!("Msg tests", tests.msg);

--- a/tests/package.d
+++ b/tests/package.d
@@ -6,6 +6,7 @@ version (D_BetterC)
     import tests.base;
     import tests.cancel;
     import tests.fsync;
+    import tests.futex;
     import tests.msg;
     import tests.poll;
     import tests.register;
@@ -22,6 +23,7 @@ version (D_BetterC)
         runTests!("API tests", tests.api);
         runTests!("Cancel tests", tests.cancel);
         runTests!("Fsync tests", tests.fsync);
+        runTests!("Futex tests", tests.futex);
         runTests!("Msg tests", tests.msg);
         runTests!("Poll tests", tests.poll);
         runTests!("Register tests", tests.register);

--- a/tests/package.d
+++ b/tests/package.d
@@ -10,10 +10,12 @@ version (D_BetterC)
     import tests.fsync;
     import tests.futex;
     import tests.msg;
+    import tests.pipe;
     import tests.poll;
     import tests.register;
     import tests.rw;
     import tests.socket;
+    import tests.sqe128;
     import tests.thread;
     import tests.timeout;
     import tests.waitid;
@@ -29,10 +31,12 @@ version (D_BetterC)
         runTests!("Fsync tests", tests.fsync);
         runTests!("Futex tests", tests.futex);
         runTests!("Msg tests", tests.msg);
+        runTests!("Pipe tests", tests.pipe);
         runTests!("Poll tests", tests.poll);
         runTests!("Register tests", tests.register);
         runTests!("RW tests", tests.rw);
         runTests!("Socket tests", tests.socket);
+        runTests!("SQE128 tests", tests.sqe128);
         runTests!("Thread tests", tests.thread);
         runTests!("Timeout tests", tests.timeout);
         runTests!("Waitid tests", tests.waitid);

--- a/tests/package.d
+++ b/tests/package.d
@@ -13,6 +13,8 @@ version (D_BetterC)
     import tests.socket;
     import tests.thread;
     import tests.timeout;
+    import tests.waitid;
+    import tests.zerocopy;
 
     import core.stdc.stdio;
     extern(C) void main()
@@ -27,6 +29,8 @@ version (D_BetterC)
         runTests!("Socket tests", tests.socket);
         runTests!("Thread tests", tests.thread);
         runTests!("Timeout tests", tests.timeout);
+        runTests!("Waitid tests", tests.waitid);
+        runTests!("Zerocopy tests", tests.zerocopy);
         printf("All unit tests have been run successfully.\n");
     }
 

--- a/tests/pipe.d
+++ b/tests/pipe.d
@@ -1,0 +1,48 @@
+module tests.pipe;
+
+import during;
+import tests.base;
+
+import core.sys.linux.errno;
+import core.sys.linux.fcntl : O_CLOEXEC;
+import core.sys.posix.unistd : close, read, write;
+
+// Async pipe creation via IORING_OP_PIPE: the kernel populates the int[2] passed in, just
+// like pipe2(2). Verify by writing to fds[1] and reading from fds[0].
+@("pipe creates working read/write pair")
+unittest
+{
+    if (!checkKernelVersion(6, 14)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    int[2] fds = [-1, -1];
+    io.putWith!(
+        (ref SubmissionEntry e, int[2]* out_)
+        {
+            e.prepPipe(*out_, O_CLOEXEC);
+            e.user_data = 1;
+        })(&fds);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res == 0, "PIPE failed");
+    assert(fds[0] >= 0 && fds[1] >= 0, "PIPE didn't fill the fd pair");
+    scope (exit) { close(fds[0]); close(fds[1]); }
+
+    ubyte[8] tx = [1,2,3,4,5,6,7,8];
+    ubyte[8] rx;
+    auto w = write(fds[1], &tx[0], tx.length);
+    assert(w == 8);
+    auto rd = read(fds[0], &rx[0], rx.length);
+    assert(rd == 8);
+    assert(rx[] == tx[]);
+}

--- a/tests/poll.d
+++ b/tests/poll.d
@@ -71,3 +71,44 @@ unittest
         io.popFront();
     }
 }
+
+// `PollFlags.ADD_LEVEL`: switch the poll from the default edge-triggered semantics to
+// level-triggered. An eventfd that's already readable when the poll is armed must complete
+// immediately — without the LEVEL flag, an edge-triggered poll would still fire here too
+// (eventfd's initial readable state acts as an edge from the poll's perspective), so the
+// real signal is that the SQE was accepted without `-EINVAL`. Linux 6.0+.
+@("poll add_level on pre-readable eventfd")
+unittest
+{
+    if (!checkKernelVersion(6, 0)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0);
+
+    auto evt = eventfd(0, EFD_NONBLOCK);
+    assert(evt != -1, "eventfd()");
+    scope (exit) close(evt);
+
+    // Make the eventfd readable before arming the poll.
+    ulong val = 1;
+    auto w = write(evt, cast(ubyte*)&val, 8);
+    assert(w == 8);
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd)
+        {
+            e.prepPollAdd(fd, PollEvents.IN, PollFlags.ADD_LEVEL);
+            e.user_data = 1;
+        })(evt);
+
+    auto sret = io.submit(0);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res >= 0, "level-triggered poll on a ready fd should succeed");
+}

--- a/tests/register.d
+++ b/tests/register.d
@@ -243,3 +243,58 @@ unittest
 {
     static assert(Operation.RECV_ZC == 58);
 }
+
+// cloneBuffers across two rings: register a buffer in `src`, clone to `dst`, then read
+// through `dst` using a fixed-buffer read to prove the buffer is accessible via dst's
+// buf_index.
+@("cloneBuffers shares registered buffer with destination ring")
+unittest
+{
+    if (!checkKernelVersion(6, 10)) return;
+
+    Uring src;
+    auto rs = src.setup();
+    assert(rs >= 0, "src setup");
+    Uring dst;
+    auto rd = dst.setup();
+    assert(rd >= 0, "dst setup");
+
+    // Register a 128-byte buffer in src.
+    ubyte[128] buf;
+    foreach (i, ref b; buf) b = cast(ubyte)i;
+    auto rr = src.registerBuffers(buf[]);
+    assert(rr == 0, "src registerBuffers");
+
+    // Clone it into dst.
+    auto cr = dst.cloneBuffers(src);
+    if (cr == -EINVAL || cr == -EOPNOTSUPP) return; // kernel without clone_buffers
+    assert(cr == 0, "cloneBuffers");
+
+    // Use the cloned buffer for a fixed read via dst.
+    auto fname = getTestFileName!"clone_buffers_test";
+    auto fd = open(&fname[0], O_CREAT | O_RDWR, 0x1a4);
+    assert(fd >= 0);
+    scope (exit) { close(fd); unlink(&fname[0]); }
+    ubyte[16] payload = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16];
+    auto w = write(fd, &payload[0], payload.length);
+    assert(w == payload.length);
+    auto lr = lseek(fd, 0, 0);
+    assert(lr == 0);
+
+    // Zero the buffer in src's address space (it's shared with dst by clone), then read
+    // through dst using the cloned buf_index=0.
+    buf[] = 0;
+    dst.putWith!(
+        (ref SubmissionEntry e, int f, ubyte[] b)
+        {
+            e.prepReadFixed(f, 0, b, 0);
+            e.user_data = 1;
+        })(fd, buf[0..payload.length]);
+    auto sret = dst.submit(1);
+    assert(sret == 1);
+    dst.wait(1);
+    auto cqe = dst.front;
+    scope (exit) dst.popFront();
+    assert(cqe.res == cast(int)payload.length, "fixed read via cloned buffer");
+    assert(buf[0..payload.length] == payload[]);
+}

--- a/tests/register.d
+++ b/tests/register.d
@@ -190,3 +190,56 @@ unittest
         assert(prob.isSupported(Operation.RECV));
     }
 }
+
+// `bufRingStatus` on a non-existent buffer group must report an error rather than crashing.
+// This validates the io_uring_register plumbing and the `io_uring_buf_status` struct layout
+// without requiring a live buf ring.
+@("bufRingStatus on missing group returns error")
+unittest
+{
+    if (!checkKernelVersion(6, 8)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    io_uring_buf_status status;
+    status.buf_group = 0xFEED;          // unlikely to exist
+    auto r = io.bufRingStatus(status);
+    assert(r < 0, "expected an error result for missing buf group");
+}
+
+// NAPI register/unregister round-trip. Many environments accept the registration even
+// without a configured NAPI-capable NIC — the call is per-ring, not per-interface — so we
+// assert success OR a kernel that returns -EINVAL for an unsupported configuration.
+@("registerNapi round-trip")
+unittest
+{
+    if (!checkKernelVersion(6, 9)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    io_uring_napi napi;
+    napi.busy_poll_to = 50;             // 50us
+    napi.prefer_busy_poll = 1;
+
+    auto rr = io.registerNapi(napi);
+    if (rr == -EINVAL || rr == -EOPNOTSUPP)
+        return;
+    assert(rr == 0, "registerNapi");
+
+    io_uring_napi out_;
+    auto ur = io.unregisterNapi(out_);
+    assert(ur == 0, "unregisterNapi");
+}
+
+// Probe-only check for RECV_ZC: confirm the opcode value matches upstream so users with a
+// supported NIC can submit it. The op needs `register_ifq` (Phase 6) to be functionally
+// testable, so we don't drive an SQE here.
+@("recv_zc opcode enumeration")
+@safe unittest
+{
+    static assert(Operation.RECV_ZC == 58);
+}

--- a/tests/rw.d
+++ b/tests/rw.d
@@ -5,9 +5,10 @@ import tests.base;
 
 import core.stdc.stdio;
 import core.stdc.stdlib;
+import core.sys.linux.errno;
 import core.sys.linux.fcntl;
 import core.sys.posix.sys.uio : iovec;
-import core.sys.posix.unistd : close, read, unlink, write;
+import core.sys.posix.unistd : close, pipe, read, unlink, write;
 import std.algorithm : copy, equal, map;
 import std.range : iota;
 
@@ -229,4 +230,75 @@ unittest
     auto rd = read(file, cast(void*)&buf[0], 256);
     assert(rd == 256);
     assert(buf[0..256].equal(iota(0, 256)));
+}
+
+@("read_multishot")
+unittest
+{
+    if (!checkKernelVersion(6, 7)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    int[2] p;
+    auto pr = pipe(p);
+    assert(pr == 0, "pipe()");
+    scope (exit) { close(p[0]); close(p[1]); }
+
+    // Provide two buffers under group 7 (IDs 0 and 1).
+    enum BGID = 7;
+    enum BSZ  = 32;
+    ubyte[BSZ * 2] pool;
+    io.putWith!(
+        (ref SubmissionEntry e, ref ubyte[BSZ * 2] mem)
+        {
+            // The (ubyte[][], len, bgid, bid) overload registers `len` buffers of equal size
+            // starting at mem.ptr — but we only have two contiguous slabs, so use the slice
+            // overload, which feeds one buffer-per-slice at the supplied starting id.
+            ubyte[][2] slabs;
+            slabs[0] = mem[0..BSZ];
+            slabs[1] = mem[BSZ..$];
+            e.prepProvideBuffers(slabs[], BSZ, BGID, 0);
+            e.user_data = 100;
+        })(pool);
+    auto sret = io.submit(1);
+    assert(sret == 1);
+    if (io.front.res < 0)
+    {
+        // PROVIDE_BUFFERS unavailable on this kernel — bail.
+        io.popFront();
+        return;
+    }
+    io.popFront();
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd)
+        {
+            e.prepReadMultishot(fd, BSZ, 0, BGID);
+            e.user_data = 200;
+        })(p[0]);
+    sret = io.submit(0);
+    assert(sret == 1);
+
+    ubyte[16] payload = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16];
+    auto w = write(p[1], &payload[0], payload.length);
+    assert(w == payload.length);
+
+    io.wait(1);
+    auto cqe = io.front;
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+    {
+        io.popFront();
+        return;
+    }
+    assert(cqe.res == cast(int)payload.length, "read_multishot byte count");
+    assert((cqe.flags & CQEFlags.BUFFER) != 0, "expected CQE_F_BUFFER");
+    // CQE_F_MORE indicates the multishot is still armed and will produce more CQEs.
+    // We don't strictly require it — the kernel is free to terminate early.
+    auto bid = cast(ushort)(cqe.flags >> CQE_BUFFER_SHIFT);
+    assert(bid < 2, "buffer id out of range");
+    auto base = bid == 0 ? pool[0..BSZ] : pool[BSZ..$];
+    assert(base[0..payload.length].equal(payload[]));
+    io.popFront();
 }

--- a/tests/rw.d
+++ b/tests/rw.d
@@ -232,6 +232,77 @@ unittest
     assert(buf[0..256].equal(iota(0, 256)));
 }
 
+// READV_FIXED / WRITEV_FIXED: vectored I/O against registered buffers. We register a single
+// scratch buffer, then issue a writev_fixed of two iovec slices (front+back of the buffer)
+// and a readv_fixed to verify the round-trip.
+@("readv_fixed / writev_fixed round-trip")
+unittest
+{
+    if (!checkKernelVersion(6, 13)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    auto fname = getTestFileName!"readv_fixed_test";
+    auto fd = openFile(fname, O_CREAT | O_RDWR);
+    scope (exit) { close(fd); unlink(&fname[0]); }
+
+    ubyte[128] regBuf;
+    auto rr = io.registerBuffers(regBuf[]);
+    assert(rr == 0);
+    scope (exit) io.unregisterBuffers();
+
+    ubyte[64] front = void;
+    ubyte[64] back  = void;
+    foreach (i; 0..64) { front[i] = cast(ubyte)i; back[i] = cast(ubyte)(64 + i); }
+    regBuf[0..64]   = front[];
+    regBuf[64..128] = back[];
+
+    iovec[2] wv;
+    wv[0].iov_base = cast(void*)&regBuf[0];   wv[0].iov_len = 64;
+    wv[1].iov_base = cast(void*)&regBuf[64];  wv[1].iov_len = 64;
+
+    io.putWith!(
+        (ref SubmissionEntry e, int f, iovec[] v)
+        {
+            e.prepWritevFixed(f, v, 0, ReadWriteFlags.NONE, 0);
+            e.user_data = 1;
+        })(fd, wv[]);
+    auto sret = io.submit(1);
+    assert(sret == 1);
+    io.wait(1);
+    auto cqe = io.front;
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+    {
+        io.popFront();
+        return;
+    }
+    assert(cqe.res == 128, "writev_fixed byte count");
+    io.popFront();
+
+    // Now zero the buffer and read back.
+    regBuf[] = 0;
+    iovec[2] rv;
+    rv[0].iov_base = cast(void*)&regBuf[0];   rv[0].iov_len = 64;
+    rv[1].iov_base = cast(void*)&regBuf[64];  rv[1].iov_len = 64;
+
+    io.putWith!(
+        (ref SubmissionEntry e, int f, iovec[] v)
+        {
+            e.prepReadvFixed(f, v, 0, ReadWriteFlags.NONE, 0);
+            e.user_data = 2;
+        })(fd, rv[]);
+    sret = io.submit(1);
+    assert(sret == 1);
+    io.wait(1);
+    cqe = io.front;
+    scope (exit) io.popFront();
+    assert(cqe.res == 128, "readv_fixed byte count");
+    assert(regBuf[0..64]   == front[]);
+    assert(regBuf[64..128] == back[]);
+}
+
 @("read_multishot")
 unittest
 {

--- a/tests/socket.d
+++ b/tests/socket.d
@@ -1,11 +1,89 @@
 module tests.socket;
 
+import during;
 import tests.base;
 
-// @("accept/connect")
-// unittest
-// {
-//     // 5.5
-//     version (D_BetterC) errmsg = "Not implemented";
-//     else throw new Exception("Not implemented");
-// }
+import core.sys.linux.errno;
+import core.sys.posix.arpa.inet : htonl;
+import core.sys.posix.netinet.in_;
+import core.sys.posix.sys.socket;
+import core.sys.posix.unistd : close;
+
+// Full in-ring socket lifecycle on TCP/127.0.0.1: BIND, LISTEN, then a non-uring connect()
+// and accept() to confirm the listening socket actually serves connections.
+@("bind/listen tcp loopback")
+unittest
+{
+    if (!checkKernelVersion(6, 11)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    int srv = socket(AF_INET, SOCK_STREAM, 0);
+    assert(srv >= 0, "socket(srv)");
+    scope (exit) close(srv);
+
+    int one = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, one.sizeof);
+
+    sockaddr_in saddr;
+    saddr.sin_family = AF_INET;
+    saddr.sin_port = 0; // kernel-assigned
+    saddr.sin_addr.s_addr = htonl(0x7f000001);
+
+    enum BIND_TAG = 1;
+    enum LISTEN_TAG = 2;
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd, sockaddr_in* a)
+        {
+            e.prepBind(fd, *a, sockaddr_in.sizeof);
+            e.user_data = BIND_TAG;
+        })(srv, &saddr);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+    io.wait(1);
+    auto cqe = io.front;
+    if (cqe.res == -EINVAL)
+    {
+        // op not present on this kernel
+        io.popFront();
+        return;
+    }
+    assert(cqe.res == 0, "BIND failed");
+    assert(cqe.user_data == BIND_TAG);
+    io.popFront();
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd)
+        {
+            e.prepListen(fd, 4);
+            e.user_data = LISTEN_TAG;
+        })(srv);
+
+    sret = io.submit(1);
+    assert(sret == 1);
+    io.wait(1);
+    cqe = io.front;
+    assert(cqe.res == 0, "LISTEN failed");
+    assert(cqe.user_data == LISTEN_TAG);
+    io.popFront();
+
+    // Confirm the socket actually listens — connect to it from a second fd.
+    sockaddr_in actual;
+    socklen_t alen = actual.sizeof;
+    auto gret = getsockname(srv, cast(sockaddr*)&actual, &alen);
+    assert(gret == 0, "getsockname()");
+
+    int cli = socket(AF_INET, SOCK_STREAM, 0);
+    assert(cli >= 0, "socket(cli)");
+    scope (exit) close(cli);
+    auto cret = connect(cli, cast(sockaddr*)&actual, alen);
+    assert(cret == 0, "connect()");
+
+    int acc = accept(srv, null, null);
+    assert(acc >= 0, "accept()");
+    close(acc);
+}

--- a/tests/sqe128.d
+++ b/tests/sqe128.d
@@ -83,3 +83,107 @@ unittest
     assert(cqe.res == 0, "NOP128 with cmd payload write");
     assert(cqe.user_data == 2);
 }
+
+@("sqe_mixed supports 64-byte and 128-byte SQEs")
+unittest
+{
+    if (!checkKernelVersion(6, 18)) return;
+
+    SetupParameters params;
+    params.flags = SetupFlags.SQE_MIXED;
+    Uring io;
+    auto res = io.setup(8, params);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "Error initializing SQE_MIXED ring");
+
+    io.putWith!((ref SubmissionEntry e)
+    {
+        e.prepNop();
+        e.user_data = 1;
+    });
+
+    auto sqe128 = &io.next128();
+    (*sqe128).prepNop128();
+    sqe128.user_data = 2;
+
+    auto sret = io.submit(2);
+    assert(sret == 3, "one 64-byte SQE plus one 128-byte SQE consumes three SQ slots");
+
+    ulong[2] seen;
+    foreach (i; 0..2)
+    {
+        auto cqe = io.front;
+        if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        {
+            io.popFront();
+            return;
+        }
+        assert(cqe.res == 0);
+        seen[i] = cqe.user_data;
+        io.popFront();
+        if (i == 0) io.wait(1);
+    }
+    assert(seen[0] == 1);
+    assert(seen[1] == 2);
+}
+
+// SQE_MIXED ring-wrap path: when a 128-byte SQE lands at the last slot of the ring, the
+// SubmissionQueue inserts a CQE_SKIP_SUCCESS NOP padder so the 128-byte SQE doesn't span
+// the wrap boundary. This is the most error-prone code path in the SQE_MIXED implementation
+// and is only reachable once `head` has advanced — i.e., after a previous submission has
+// drained — so we explicitly drain the ring first to set up the right state.
+@("sqe_mixed pads a 128-byte SQE that would wrap the ring end")
+unittest
+{
+    if (!checkKernelVersion(6, 18)) return;
+
+    SetupParameters params;
+    params.flags = SetupFlags.SQE_MIXED;
+    Uring io;
+    auto res = io.setup(16, params);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "Error initializing SQE_MIXED ring");
+
+    // Drain 8 slots so head advances to 8; this frees up the ring head for the wrap path.
+    foreach (i; 0UL .. 8UL)
+    {
+        io.putWith!((ref SubmissionEntry e, ulong t)
+            { e.prepNop(); e.user_data = t; })(i);
+    }
+    auto sret = io.submit(8);
+    assert(sret == 8);
+    foreach (_; 0..8) io.popFront();
+
+    // Fill slots 8..14 with NOPs (localTail = 15), then a NOP128. localTail mod 16 == 15
+    // is the wrap boundary, so reserve128Slot inserts a CQE_SKIP_SUCCESS padder at slot 15
+    // and places the NOP128 at slots 16/17 (ring positions 0/1).
+    foreach (i; 100UL .. 107UL)
+    {
+        io.putWith!((ref SubmissionEntry e, ulong t)
+            { e.prepNop(); e.user_data = t; })(i);
+    }
+    auto sqe128 = &io.next128();
+    (*sqe128).prepNop128();
+    sqe128.user_data = 200;
+
+    // 7 NOPs + 1 padder + 1 NOP128 (occupies 2 slots) = 10 SQ slots; the padder carries
+    // CQE_SKIP_SUCCESS so the kernel emits only 8 CQEs.
+    sret = io.submit(8);
+    assert(sret == 10, "wrap-pad consumes one extra SQ slot");
+
+    ulong[8] seen;
+    foreach (i; 0..8)
+    {
+        auto cqe = io.front;
+        if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        {
+            io.popFront();
+            return;
+        }
+        assert(cqe.res == 0);
+        seen[i] = cqe.user_data;
+        io.popFront();
+    }
+    foreach (i; 0..7) assert(seen[i] == 100 + i, "pre-wrap NOPs complete in order");
+    assert(seen[7] == 200, "NOP128 completes after the padder is skipped");
+}

--- a/tests/sqe128.d
+++ b/tests/sqe128.d
@@ -3,15 +3,83 @@ module tests.sqe128;
 import during;
 import tests.base;
 
-// IMPORTANT: `Operation.NOP128` and `Operation.URING_CMD128` are exposed for users who provide
-// their own SQE storage with a 128-byte stride. The default `during.Uring` mmaps the SQE region
-// at `entries * SubmissionEntry.sizeof` (=64), so a ring set up with `SetupFlags.SQE128` would
-// either be rejected by the kernel (mmap size mismatch) or read out-of-bounds. Fixing this
-// needs a follow-up commit that rebuilds the SQE storage with a runtime stride when the flag
-// is set; until then this test only asserts the opcode values match upstream.
-@("nop128 / uring_cmd128 opcode enumeration")
+import core.sys.linux.errno;
+
+@("nop128 opcode enumeration")
 @safe unittest
 {
     static assert(Operation.NOP128 == 63);
     static assert(Operation.URING_CMD128 == 64);
+}
+
+// Functional SQE128 round-trip via NOP128. With `SetupFlags.SQE128` the kernel exposes
+// 128-byte SQE slots; the SubmissionQueue setup now picks the right stride for the mmap
+// so the second half of each slot is real memory. NOP128 doesn't actually consume the
+// trailing cmd payload — it's the simplest op that requires the SQE128 ring layout.
+@("nop128 round-trip on SQE128 ring")
+unittest
+{
+    if (!checkKernelVersion(6, 16)) return;
+
+    SetupParameters params;
+    params.flags = SetupFlags.SQE128;
+    Uring io;
+    auto res = io.setup(8, params);
+    if (res == -EINVAL) return; // kernel without SQE128 support — bail.
+    assert(res >= 0, "Error initializing IO");
+
+    io.putWith!((ref SubmissionEntry e)
+    {
+        e.prepNop128();
+        e.user_data = 1;
+    });
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return; // op not present on this kernel
+    assert(cqe.res == 0, "NOP128 should succeed");
+    assert(cqe.user_data == 1);
+}
+
+// Same idea but writes through the trailing cmd payload that SQE128 mode makes addressable.
+// We don't have a kernel handler that inspects cmd data for NOP128, but the write itself
+// must not segfault and must not corrupt the SQE header (assertion: NOP128 still completes
+// cleanly after we write 64 bytes to the cmd region).
+@("SQE128 cmd payload is addressable")
+unittest
+{
+    if (!checkKernelVersion(6, 16)) return;
+
+    SetupParameters params;
+    params.flags = SetupFlags.SQE128;
+    Uring io;
+    auto res = io.setup(8, params);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "Error initializing IO");
+
+    {
+        auto sqe = &io.next();
+        (*sqe).prepNop128();
+        sqe.user_data = 2;
+        // Write into the trailing 64 bytes of the slot via the zero-length cmd[] field.
+        // In a real URING_CMD128 op the kernel reads these bytes; for NOP128 it ignores
+        // them, so all we're checking is that the memory is writable (no segfault) and
+        // the SQE header survives intact (assertion below).
+        auto tail = (cast(ubyte*)sqe.cmd.ptr)[0..64];
+        foreach (i, ref b; tail) b = cast(ubyte)(0xC0 ^ i);
+    }
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res == 0, "NOP128 with cmd payload write");
+    assert(cqe.user_data == 2);
 }

--- a/tests/sqe128.d
+++ b/tests/sqe128.d
@@ -1,0 +1,17 @@
+module tests.sqe128;
+
+import during;
+import tests.base;
+
+// IMPORTANT: `Operation.NOP128` and `Operation.URING_CMD128` are exposed for users who provide
+// their own SQE storage with a 128-byte stride. The default `during.Uring` mmaps the SQE region
+// at `entries * SubmissionEntry.sizeof` (=64), so a ring set up with `SetupFlags.SQE128` would
+// either be rejected by the kernel (mmap size mismatch) or read out-of-bounds. Fixing this
+// needs a follow-up commit that rebuilds the SQE storage with a runtime stride when the flag
+// is set; until then this test only asserts the opcode values match upstream.
+@("nop128 / uring_cmd128 opcode enumeration")
+@safe unittest
+{
+    static assert(Operation.NOP128 == 63);
+    static assert(Operation.URING_CMD128 == 64);
+}

--- a/tests/timeout.d
+++ b/tests/timeout.d
@@ -1,19 +1,86 @@
 module tests.timeout;
 
+import during;
 import tests.base;
 
-// @("timeout set/remove")
-// unittest
-// {
-//     // set 5.4, remove 5.5
-//     version (D_BetterC) errmsg = "Not implemented";
-//     else throw new Exception("Not implemented");
-// }
+import core.sys.linux.errno;
 
-// @("link timeout")
-// unittest
-// {
-//     // 5.5
-//     version (D_BetterC) errmsg = "Not implemented";
-//     else throw new Exception("Not implemented");
-// }
+// `TimeoutFlags.MULTISHOT`: each fire produces a CQE with `CQEFlags.MORE`; the request
+// remains armed until `count` fires have happened (or it's cancelled), at which point the
+// final CQE arrives without `MORE` set. Linux 6.4+.
+@("timeout multishot fires repeatedly")
+unittest
+{
+    if (!checkKernelVersion(6, 4)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0);
+
+    KernelTimespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 1_000_000; // 1ms
+
+    enum FIRES = 3;
+    io.putWith!(
+        (ref SubmissionEntry e, ref KernelTimespec t)
+        {
+            e.prepTimeout(t, FIRES, TimeoutFlags.MULTISHOT);
+            e.user_data = 1;
+        })(ts);
+    auto sret = io.submit(0);
+    assert(sret == 1);
+
+    int seen;
+    bool lastHadMore = true;
+    while (seen < FIRES)
+    {
+        io.wait(1);
+        auto cqe = io.front;
+        if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        {
+            io.popFront();
+            return; // kernel without multishot timeout
+        }
+        // Each completion is either -ETIME (per-fire) or 0 on the final cancel/timeout
+        // depending on kernel version. We only assert on the F_MORE/last semantics.
+        seen++;
+        lastHadMore = (cqe.flags & CQEFlags.MORE) != 0;
+        io.popFront();
+    }
+    assert(seen == FIRES, "expected FIRES completions");
+    assert(!lastHadMore, "last multishot CQE must clear F_MORE");
+}
+
+// `TimeoutFlags.IMMEDIATE_ARG`: `addr` carries a u64 nanoseconds value instead of a pointer
+// to a timespec. Kernel returns `-ETIME` after the duration. Linux 6.18+.
+@("timeout immediate_arg accepts inline nanoseconds")
+unittest
+{
+    if (!checkKernelVersion(6, 18)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0);
+
+    // Build a minimal SQE by hand since `prepTimeout` assumes the pointer form.
+    auto sqe = &io.next();
+    *sqe = SubmissionEntry.init;
+    sqe.opcode = Operation.TIMEOUT;
+    sqe.fd = -1;
+    sqe.addr = 500_000;                 // 500us
+    sqe.len = 1;                        // count
+    sqe.off = 0;
+    sqe.timeout_flags = TimeoutFlags.IMMEDIATE_ARG;
+    sqe.user_data = 1;
+
+    auto sret = io.submit(0);
+    assert(sret == 1);
+
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+        return;
+    assert(cqe.res == -ETIME, "IMMEDIATE_ARG timeout should report -ETIME");
+}

--- a/tests/wait_reg.d
+++ b/tests/wait_reg.d
@@ -1,0 +1,77 @@
+module tests.wait_reg;
+
+import during;
+import tests.base;
+
+import core.sys.linux.errno;
+
+// Posix CLOCK ids exposed by the kernel. CLOCK_BOOTTIME isn't in druntime's posix bindings
+// (it's Linux-specific), so define just the two we need locally.
+private enum CLOCK_MONOTONIC = 1;
+private enum CLOCK_BOOTTIME  = 7;
+
+// `registerClock` swaps the kernel-side clock source used for ring-side timeouts.
+@("registerClock accepts known clock ids")
+unittest
+{
+    if (!checkKernelVersion(6, 10)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0);
+
+    // CLOCK_MONOTONIC is the default for io_uring timeouts — re-registering it is a no-op.
+    auto rr = io.registerClock(CLOCK_MONOTONIC);
+    if (rr == -EINVAL || rr == -EOPNOTSUPP) return;
+    assert(rr == 0, "registerClock(CLOCK_MONOTONIC)");
+
+    // CLOCK_BOOTTIME is the other clock the kernel definitely accepts.
+    auto rr2 = io.registerClock(CLOCK_BOOTTIME);
+    assert(rr2 == 0 || rr2 == -EINVAL, "registerClock(CLOCK_BOOTTIME)");
+}
+
+// Stub-coverage of the wait-arg registration path. The actual kernel rejects this until
+// a wait region is filled in via REGISTER_MEM_REGION first; we exercise the call so we
+// catch any wire-up regressions even on kernels that return -EINVAL.
+@("registerWaitReg surface check")
+unittest
+{
+    if (!checkKernelVersion(6, 13)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0);
+
+    io_uring_reg_wait[2] entries;
+    entries[0].ts.tv_sec = 1;
+    entries[0].min_wait_usec = 100;
+    entries[1].ts.tv_nsec = 1_000_000; // 1ms
+    entries[1].min_wait_usec = 10;
+
+    auto rr = io.registerWaitReg(entries[]);
+    // Accept success (regions API enabled) or kernel rejection (older or incomplete).
+    assert(rr == 0 || rr == -EINVAL || rr == -EOPNOTSUPP,
+        "unexpected registerWaitReg result");
+}
+
+@("registerBpfFilter uses structured bpf payload")
+unittest
+{
+    static assert(io_uring_bpf_filter.sizeof == 64);
+    static assert(io_uring_bpf.sizeof == 72);
+
+    if (!checkKernelVersion(6, 16)) return;
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0);
+
+    io_uring_bpf bpf;
+    bpf.cmd_type = IO_URING_BPF_CMD_FILTER;
+    bpf.filter.opcode = Operation.NOP;
+    bpf.filter.filter_len = 1;
+    bpf.filter.filter_ptr = 0; // invalid user pointer; validates the structured ABI path.
+
+    auto rr = io.registerBpfFilter(bpf);
+    assert(rr < 0, "expected a negative result");
+}

--- a/tests/waitid.d
+++ b/tests/waitid.d
@@ -1,0 +1,67 @@
+module tests.waitid;
+
+import during;
+import tests.base;
+
+import core.stdc.stdlib : exit;
+import core.sys.linux.errno;
+import core.sys.posix.signal : siginfo_t;
+import core.sys.posix.sys.wait : waitpid, WNOHANG;
+import core.sys.posix.unistd : fork, _exit;
+
+// idtype_t values from sys/wait.h. Not in druntime as a portable enum, so we hardcode.
+private enum P_ALL  = 0;
+private enum P_PID  = 1;
+private enum P_PGID = 2;
+
+// options bits we need. WEXITED is required by waitid(2).
+private enum WEXITED = 0x00000004;
+
+@("waitid child exit")
+unittest
+{
+    if (!checkKernelVersion(6, 5)) return;
+
+    auto pid = fork();
+    assert(pid >= 0, "fork()");
+    if (pid == 0)
+    {
+        // child: exit immediately with code 42.
+        _exit(42);
+    }
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    siginfo_t info;
+    io.putWith!(
+        (ref SubmissionEntry e, int p, siginfo_t* infop)
+        {
+            e.prepWaitid(P_PID, cast(uint)p, infop, WEXITED, 0);
+            e.user_data = 1;
+        })(pid, &info);
+
+    auto sret = io.submit(1);
+    assert(sret == 1);
+
+    auto cqe = io.front;
+    if (cqe.res == -EINVAL)
+    {
+        // op not supported on this kernel — reap the child synchronously and bail.
+        int status;
+        waitpid(pid, &status, 0);
+        io.popFront();
+        return;
+    }
+    assert(cqe.res == 0, "prepWaitid completion failed");
+    assert(cqe.user_data == 1);
+    io.popFront();
+
+    // siginfo_t::si_status holds the child exit code; the field name varies by
+    // libc, so check via the raw struct rather than asserting a specific code.
+    // (We at least confirmed the op succeeded and the child has been reaped.)
+    int status;
+    auto wp = waitpid(pid, &status, WNOHANG);
+    assert(wp == -1 || wp == 0, "child should already be reaped by IORING_OP_WAITID");
+}

--- a/tests/zerocopy.d
+++ b/tests/zerocopy.d
@@ -1,0 +1,113 @@
+module tests.zerocopy;
+
+import during;
+import tests.base;
+
+import core.stdc.stdio : printf;
+import core.stdc.stdlib;
+import core.sys.linux.errno;
+import core.sys.posix.arpa.inet : htons;
+import core.sys.posix.netinet.in_;
+import core.sys.posix.sys.socket;
+import core.sys.posix.unistd : close, read;
+
+import std.algorithm : copy, equal, map;
+import std.range : iota;
+
+// Loopback `IORING_OP_SEND_ZC` round-trip over a TCP socket. The kernel's zero-copy fast path
+// is only enabled for real network sockets (AF_INET TCP/UDP), so a UNIX socketpair won't work.
+// Each SEND_ZC generates two CQEs: the send result with CQE_F_MORE set, then a notification
+// with CQE_F_NOTIF emitted once the kernel is done with the user pages.
+@("send_zc tcp loopback")
+unittest
+{
+    if (!checkKernelVersion(6, 0)) return;
+
+    int srv = socket(AF_INET, SOCK_STREAM, 0);
+    assert(srv >= 0, "socket(srv)");
+    scope (exit) close(srv);
+
+    int one = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, one.sizeof);
+
+    sockaddr_in saddr;
+    saddr.sin_family = AF_INET;
+    saddr.sin_port = 0; // kernel-assigned
+    saddr.sin_addr.s_addr = htonl(0x7f000001); // 127.0.0.1
+    auto bret = bind(srv, cast(sockaddr*)&saddr, saddr.sizeof);
+    assert(bret == 0, "bind()");
+    auto lret = listen(srv, 1);
+    assert(lret == 0, "listen()");
+
+    sockaddr_in actual;
+    socklen_t alen = actual.sizeof;
+    auto gret = getsockname(srv, cast(sockaddr*)&actual, &alen);
+    assert(gret == 0, "getsockname()");
+
+    int cli = socket(AF_INET, SOCK_STREAM, 0);
+    assert(cli >= 0, "socket(cli)");
+    scope (exit) close(cli);
+    auto cret = connect(cli, cast(sockaddr*)&actual, alen);
+    assert(cret == 0, "connect()");
+
+    sockaddr_in peer;
+    socklen_t plen = peer.sizeof;
+    int acc = accept(srv, cast(sockaddr*)&peer, &plen);
+    assert(acc >= 0, "accept()");
+    scope (exit) close(acc);
+
+    Uring io;
+    auto res = io.setup();
+    assert(res >= 0, "Error initializing IO");
+
+    enum N = 256;
+    ubyte[N] payload;
+    iota(0, N).map!(a => cast(ubyte)a).copy(payload[]);
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd, ubyte[] buf)
+        {
+            e.prepSendZc(fd, buf, MsgFlags.NONE, IORING_SEND_ZC_REPORT_USAGE);
+            e.user_data = 1;
+        })(cli, payload[]);
+
+    auto sret = io.submit(0);
+    assert(sret == 1);
+
+    int sendRes = int.min;
+    bool gotMore;
+    bool gotNotif;
+    uint notifRes;
+
+    foreach (_; 0..2)
+    {
+        io.wait(1);
+        auto cqe = io.front;
+        scope (exit) io.popFront();
+        if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP)
+            return; // op not supported on this kernel/config — bail.
+        if (cqe.flags & CQEFlags.NOTIF)
+        {
+            gotNotif = true;
+            notifRes = cast(uint)cqe.res;
+        }
+        else
+        {
+            assert(cqe.res >= 0, "send_zc failed");
+            sendRes = cqe.res;
+            gotMore = (cqe.flags & CQEFlags.MORE) != 0;
+        }
+    }
+
+    assert(gotMore, "send result CQE must carry CQE_F_MORE");
+    assert(gotNotif, "expected a CQE_F_NOTIF completion");
+    assert(sendRes == N, "wrong byte count");
+    // notifRes == 0 means true zerocopy; IORING_NOTIF_USAGE_ZC_COPIED means kernel had to copy.
+    assert(notifRes == 0 || notifRes == IORING_NOTIF_USAGE_ZC_COPIED);
+
+    // Drain the receiving side and confirm the payload survived the trip.
+    ubyte[N] rx;
+    auto rd = read(acc, &rx[0], rx.length);
+    assert(rd == N);
+    assert(rx[].equal(payload[]));
+}


### PR DESCRIPTION
## Summary

Brings `during` up to **liburing 2.9 / Linux 7.1-rc4** parity. The last
release (0.4.0) was synced to Linux 5.19, so the bulk of liburing 2.7–2.9
plus the post-2.9 kernel additions through 7.1-rc4 was missing. This PR
closes that gap.

Quantified: **18 new opcodes**, **14 new register opcodes**, **9 new
setup flags**, **5 new feature bits**, plus the structural changes to
the SQE / CQE storage paths that the new variable-stride rings
(`SQE128`, `SQE_MIXED`, `CQE32`, `CQE_MIXED`) require. 38 of the 56
unittest blocks are new and exercise the new prep helpers, register
wrappers, and ring-storage paths; kernel-gated tests bail cleanly on
older hosts via `checkKernelVersion()`.

The branch is shaped as **15 atomic commits**, one feature group per
commit, intended to be reviewed and merged in order.

## What's in here

**Opcodes (18 new):**

| Kernel | Op | Prep helper |
|---|---|---|
| 6.0 | `SEND_ZC` | `prepSendZc`, `prepSendZcFixed` |
| 6.0 | `SENDMSG_ZC` | `prepSendmsgZc` |
| 6.1 | `READ_MULTISHOT` | `prepReadMultishot` |
| 6.5 | `WAITID` | `prepWaitid` |
| 6.7 | `FUTEX_WAIT` | `prepFutexWait` |
| 6.7 | `FUTEX_WAKE` | `prepFutexWake` |
| 6.7 | `FUTEX_WAITV` | `prepFutexWaitv` |
| 6.7 | `FIXED_FD_INSTALL` | `prepFixedFdInstall` |
| 6.7 | `FTRUNCATE` | `prepFtruncate` |
| 6.11 | `BIND` | `prepBind` |
| 6.11 | `LISTEN` | `prepListen` |
| 6.13 | `RECV_ZC` | `prepRecvZc` |
| 6.13 | `EPOLL_WAIT` | `prepEpollWait` |
| 6.13 | `READV_FIXED` | `prepReadvFixed` |
| 6.13 | `WRITEV_FIXED` | `prepWritevFixed` |
| 6.14 | `PIPE` | `prepPipe`, `prepPipeDirect` |
| 6.16 | `NOP128` | `prepNop128` |
| 6.16 | `URING_CMD128` | `prepUringCmd128` |

Plus generic `URING_CMD` helpers (`prepUringCmd`, `prepCmdSock`,
`prepCmdGetsockname`, `prepCmdDiscard`) layered over the pre-existing
`URING_CMD` opcode.

**Register opcodes (14 new):**

| Kernel | Register op | Wrapper |
|---|---|---|
| 6.0 | `REGISTER_SYNC_CANCEL` | `Uring.registerSyncCancel` |
| 6.0 | `REGISTER_FILE_ALLOC_RANGE` | `Uring.registerFileAllocRange` |
| 6.8 | `REGISTER_PBUF_STATUS` | `Uring.bufRingStatus` |
| 6.9 | `REGISTER_NAPI` | `Uring.registerNapi` |
| 6.9 | `UNREGISTER_NAPI` | `Uring.unregisterNapi` |
| 6.10 | `REGISTER_CLOCK` | `Uring.registerClock` |
| 6.10 | `REGISTER_CLONE_BUFFERS` | `Uring.cloneBuffers`, `cloneBuffersOffset` |
| 6.10 | `REGISTER_SEND_MSG_RING` | `Uring.sendMsgRingSync` |
| 6.11 | `REGISTER_ZCRX_IFQ` | `Uring.registerIfq` |
| 6.12 | `REGISTER_RESIZE_RINGS` | `Uring.resizeRings` |
| 6.13 | `REGISTER_MEM_REGION` | `Uring.registerMemRegion`, `registerWaitReg` |
| 6.15 | `REGISTER_QUERY` | — (raw opcode only) |
| 6.16 | `REGISTER_ZCRX_CTRL` | — (raw opcode only) |
| 6.16 | `REGISTER_BPF_FILTER` | `Uring.registerBpfFilter` |

**Setup flags (9 new):**

| Kernel | Flag | Notes |
|---|---|---|
| 6.0 | `SINGLE_ISSUER` | promises a single issuer thread; unlocks `DEFER_TASKRUN` |
| 6.1 | `DEFER_TASKRUN` | requires `SINGLE_ISSUER` |
| 6.5 | `NO_MMAP` | rejected at wrapper boundary — needs caller-owned ring memory |
| 6.5 | `REGISTERED_FD_ONLY` | rejected — depends on `NO_MMAP` path |
| 6.6 | `NO_SQARRAY` | wrapper skips SQ-array init |
| 6.13 | `HYBRID_IOPOLL` | IOPOLL with sleep-then-spin instead of pure busy-poll |
| 6.18 | `CQE_MIXED` | see *Storage-path changes* |
| 6.18 | `SQE_MIXED` | see *Storage-path changes* |
| 6.18 | `SQ_REWIND` | see *Storage-path changes* |

Existing `SQE128` / `CQE32` rings now have the storage-path support
they were missing.

**Storage-path changes:**
- `SubmissionQueue` now selects the SQE stride (64 B or 128 B) at setup
  time based on `SetupFlags.SQE128`. The previous code hardcoded
  `entries * 64`, leaving the trailing `cmd[]` payload of SQE128 rings
  outside the mapped region — `NOP128` and `URING_CMD128` were unusable.
- For `SQE_MIXED` rings, a new `next128()` accessor reserves two
  contiguous 64-byte slots and inserts a `CQE_SKIP_SUCCESS` NOP padder
  if a 128-byte SQE would straddle the ring wrap.
- For `SQ_REWIND` rings, `head()` returns 0 unconditionally,
  `flushTail()` becomes a no-op, and `localTail` resets after each
  acknowledged batch.
- `CompletionQueue` walks variable-stride CQEs: a per-ring `shift`
  doubles the cqes slice for `CQE32` rings, and `popFront` / `peekAt`
  advance by 1 or 2 ring slots depending on the per-CQE `F_32` flag.

**Examples:**
- `examples/zerocopy_echo` — TCP echo over `IORING_OP_SEND_ZC`,
  asserts the kernel emits both the data CQE and the trailing
  notification CQE.
- `examples/futex_pingpong` — two threads, io_uring `FUTEX_WAIT` woken
  via legacy `futex(2) FUTEX_WAKE_PRIVATE`.

**Build / dev infra:**
- All `dub.sdl` package files now set `targetPath "build"` so example
  binaries land in `build/` instead of in the example root. `build/`
  is git-ignored.
- New Nix flake + direnv devshell (purely additive; doesn't touch
  dub). Happy to drop this commit if upstream prefers not to carry it.

## Test plan

- [x] **`dub test -- --threads=1`** — all 56 unit tests pass serially.
      The default parallel `silly` runner has transient `-EMFILE` flakes
      on `io_uring_setup` when many tests open rings at once (a known
      `silly`-runner artefact, not a regression). Serial run is stable.
- [x] **`dub build --config=betterC`** — green; the new APIs remain
      BetterC-compatible.
- [x] **`dub build --config=during-test-betterC`** — green.
- [x] **`dub build` in each example** — `examples/echo_server`,
      `examples/zerocopy_echo`, `examples/futex_pingpong` all build and
      land their binaries in their per-example `build/` directory.
- [x] **Probe sanity** — `tests.register probe` runs and confirms the
      6.18 host enumerates all new opcodes.

## Test environment

The branch was developed and tested on:

- **OS**: NixOS 25.11 (Xantusia), kernel `6.18.17` x86_64
- **CPU**: AMD Ryzen 9 7940HX
- **Compiler**: LDC 1.41.0 (DMD v2.111.0 frontend, LLVM 18.1.8)
- **dub**: 1.39.0
- **Toolchain pinned via**: the `flake.nix` introduced in this PR
  (`nixpkgs` rev `549bd84`)

## Sources used for grounding

Every opcode number, register opcode number, struct field, flag bit,
and feature bit was cross-checked against:

- A local clone of **`torvalds/linux`** at v7.1-rc4 (`io_uring/`,
  `include/uapi/linux/io_uring.h`, `include/linux/io_uring*.h`).
- A local clone of **`axboe/liburing`** at v2.9
  (`src/include/liburing/io_uring.h` plus the `src/queue.c` /
  `src/register.c` reference implementations of the new helpers).

Wrong opcode numbers are the single highest-risk class of bug in this
kind of catch-up work — they silently misroute requests on real
kernels — so each commit was reviewed against the kernel header
before it was finalised.

## LLM disclosure

The bulk of this PR was drafted with **Claude Opus 4.7 (high reasoning,
1M-token context)**, with a follow-up review pass by **GPT-5.5 Codex (high
reasoning)**. Throughout, the assistants were grounded against the local kernel
and liburing git trees noted above rather than relying on training data. New
prep helpers and register wrappers have focused functional or ABI-surface tests
where the operation can be exercised on a stock test host; hardware- or
configuration-dependent paths are covered by compile-time layout checks and
structured-call smoke tests.

