### PR TITLE
fix: finish liburing 2.9 / Linux 7.1-rc4 sync

### DIFF
--- a/source/during/io_uring.d
+++ b/source/during/io_uring.d
@@ -2,8 +2,9 @@
  * io_uring system api definitions.
  *
  * See: https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring.h
+ *      https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring/zcrx.h
  *
- * Last changes from: bdb2c48e4b38e6dbe82533b437468999ba3ae498 (20220708)
+ * Last changes from: 5200f5f493f79f14bbdc349e402a40dfb32f23c8 (20260517, v7.1-rc4)
  */
 module during.io_uring;
 
@@ -605,6 +606,14 @@ enum IORING_MSG_RING_CQE_SKIP       = 1U << 0;
 /// `MSG_RING` flag (`sqe->msg_ring_flags`). When set, the kernel passes the value stored in
 /// `sqe->file_index` as the target CQE's flags field. From Linux 6.3.
 enum IORING_MSG_RING_FLAGS_PASS     = 1U << 1;
+
+/// `IORING_OP_MSG_RING` command type (stored in `sqe->addr`) — `enum io_uring_msg_ring_flags`.
+/// `IORING_MSG_DATA`: pass `sqe->len` as the target CQE's `res` and `sqe->off` as its `user_data`.
+enum IORING_MSG_DATA                = 0;
+
+/// `IORING_OP_MSG_RING` command type (stored in `sqe->addr`). `IORING_MSG_SEND_FD`: send a
+/// registered file descriptor to another ring.
+enum IORING_MSG_SEND_FD             = 1;
 
 /// `IORING_OP_URING_CMD` / `URING_CMD128` flag (`sqe->uring_cmd_flags`). Use the registered
 /// buffer addressed by `sqe->buf_index` for the command's data payload. From Linux 6.0.
@@ -1813,6 +1822,11 @@ enum RegisterOpCode : uint
     /// `IORING_REGISTER_BPF_FILTER` (from Linux 6.16)
     /// Register a BPF program that filters completions before they reach userspace.
     REGISTER_BPF_FILTER      = 37,
+
+    /// `IORING_REGISTER_USE_REGISTERED_RING` — not an opcode but a flag OR'd into the opcode
+    /// argument of `io_uring_register(2)` to signal that `fd` is a registered ring index
+    /// (registered via `IORING_REGISTER_RING_FDS`) rather than a real file descriptor.
+    REGISTER_USE_REGISTERED_RING = 1U << 31,
 }
 
 /* io-wq worker categories */
@@ -1956,6 +1970,98 @@ struct io_uring_restriction
     uint[3] resv2;
 }
 
+/**
+ * Argument to `IORING_REGISTER_TASK_RESTRICTIONS` — registers a set of per-task restrictions.
+ * `restrictions` is a flex array of `nr_res` entries.
+ *
+ * Note: Available from Linux 7.0
+ */
+struct io_uring_task_restriction
+{
+    ushort  flags;
+    ushort  nr_res;                     /// number of entries in `restrictions`
+    uint[3] resv;
+    io_uring_restriction[0] restrictions;
+}
+
+static assert(io_uring_task_restriction.sizeof == 16);
+
+/**
+ * PI (protection information) attribute, pointed at by `sqe->attr_ptr` when the request carries
+ * `IORING_RW_ATTR_FLAG_PI` in `sqe->attr_type_mask`.
+ *
+ * Note: Available from Linux 6.13
+ */
+struct io_uring_attr_pi
+{
+    ushort  flags;
+    ushort  app_tag;
+    uint    len;
+    ulong   addr;
+    ulong   seed;
+    ulong   rsvd;
+}
+
+static assert(io_uring_attr_pi.sizeof == 32);
+
+/// Argument to `IORING_REGISTER_FILES_UPDATE` — updates `fds` starting at `offset`.
+struct io_uring_files_update
+{
+    uint    offset;
+    private uint resv;
+    ulong   fds;                        /// `int *` cast to u64
+}
+
+static assert(io_uring_files_update.sizeof == 16);
+
+/// Argument to `IORING_REGISTER_BUFFERS2` / `IORING_REGISTER_FILES2`.
+struct io_uring_rsrc_register
+{
+    uint    nr;
+    uint    flags;                      /// `IORING_RSRC_REGISTER_SPARSE`
+    private ulong resv2;
+    ulong   data;
+    ulong   tags;
+}
+
+static assert(io_uring_rsrc_register.sizeof == 32);
+
+/// Argument to `IORING_REGISTER_FILES_UPDATE` / `IORING_REGISTER_BUFFERS_UPDATE`.
+struct io_uring_rsrc_update
+{
+    uint    offset;
+    private uint resv;
+    ulong   data;
+}
+
+static assert(io_uring_rsrc_update.sizeof == 16);
+
+/// Argument to `IORING_REGISTER_FILES_UPDATE2` / `IORING_REGISTER_BUFFERS_UPDATE` — like
+/// `io_uring_rsrc_update` but carries resource `tags` and an explicit count.
+struct io_uring_rsrc_update2
+{
+    uint    offset;
+    private uint resv;
+    ulong   data;
+    ulong   tags;
+    uint    nr;
+    private uint resv2;
+}
+
+static assert(io_uring_rsrc_update2.sizeof == 32);
+
+/// Header the kernel prepends to the buffer of an `IORING_OP_RECVMSG` request issued with
+/// `IORING_RECVSEND_MULTISHOT`, describing how to locate name/control/payload in the buffer.
+struct io_uring_recvmsg_out
+{
+    uint    namelen;
+    uint    controllen;
+    uint    payloadlen;
+    uint    flags;
+}
+
+static assert(io_uring_recvmsg_out.sizeof == 16);
+
 struct io_uring_buf
 {
     ulong   addr;
@@ -1983,15 +2089,22 @@ struct io_uring_buf_ring
     }
 }
 
+/// `io_uring_buf_reg.flags` — `enum io_uring_register_pbuf_ring_flags`.
+enum IOU_PBUF_RING_MMAP = 1;    /// ring is allocated by the kernel and mmaped by the app
+enum IOU_PBUF_RING_INC  = 2;    /// incremental buffer consumption
+
 /* argument for IORING_(UN)REGISTER_PBUF_RING */
 struct io_uring_buf_reg
 {
     ulong       ring_addr;
     uint        ring_entries;
     ushort      bgid;
-    ushort      pad;
-    ulong[3]    resv;
+    ushort      flags;          /// see `IOU_PBUF_RING_MMAP` / `IOU_PBUF_RING_INC`
+    uint        min_left;       /// minimum free buffers before -ENOBUFS (incremental rings)
+    uint[5]     resv;
 }
+
+static assert(io_uring_buf_reg.sizeof == 40);
 
 /**
  * Argument to `IORING_REGISTER_SYNC_CANCEL`. Synchronously cancels matching in-flight
@@ -2266,6 +2379,50 @@ struct io_uring_zcrx_ifq_reg
     ulong[3]    __resv;
 }
 
+/// `io_uring_zcrx_ifq_reg.flags` — `enum zcrx_reg_flags`.
+enum ZCRX_REG_IMPORT = 1;           /// import an ifq registered by another ring
+enum ZCRX_REG_NODEV  = 2;           /// register without binding to a netdev
+
+/// `enum zcrx_features` — feature bits for zcrx.
+enum ZCRX_FEATURE_RX_PAGE_SIZE = 1 << 0;
+
+/// Subcommand selector for `IORING_REGISTER_ZCRX_CTRL` (`zcrx_ctrl.op`) — `enum zcrx_ctrl_op`.
+enum ZCRX_CTRL_FLUSH_RQ = 0;        /// flush the refill queue
+enum ZCRX_CTRL_EXPORT   = 1;        /// export the zcrx area as a file descriptor
+
+/// `ZCRX_CTRL_FLUSH_RQ` payload (reserved).
+struct zcrx_ctrl_flush_rq
+{
+    ulong[6] __resv;
+}
+
+/// `ZCRX_CTRL_EXPORT` payload — receives the exported zcrx file descriptor.
+struct zcrx_ctrl_export
+{
+    uint     zcrx_fd;
+    uint[11] __resv1;
+}
+
+/// Argument to `IORING_REGISTER_ZCRX_CTRL`. `op` selects the subcommand (`zcrx_ctrl_op`).
+struct zcrx_ctrl
+{
+    uint        zcrx_id;
+    uint        op;                 /// see `zcrx_ctrl_op`
+    ulong[2]    __resv;
+    union
+    {
+        zcrx_ctrl_export    zc_export;
+        zcrx_ctrl_flush_rq  zc_flush;
+    }
+}
+
+static assert(zcrx_ctrl_flush_rq.sizeof == 48);
+static assert(zcrx_ctrl_export.sizeof == 48);
+static assert(zcrx_ctrl.sizeof == 72);
+
+/// `io_uring_reg_wait.flags` bit — when set, `ts` carries a valid wait timeout.
+enum IORING_REG_WAIT_TS = 1U << 0;
+
 /**
  * Wait-registration entry passed to `IORING_REGISTER_MEM_REGION` with
  * `IORING_MEM_REGION_REG_WAIT_ARG` set. Each entry pre-configures a wait timeout (`ts`),
@@ -2324,7 +2481,7 @@ struct io_uring_getevents_arg
 {
     ulong   sigmask;
     uint    sigmask_sz;
-    uint    pad;
+    uint    min_wait_usec;
     ulong   ts;
 }
 

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -69,6 +69,7 @@ int setup(ref Uring uring, uint entries, ref const SetupParameters params) @safe
     if (r < 0) return -errno;
 
     uring.payload.fd = r;
+    uring.payload.enterFd = r; // until/unless registerRingFd() swaps in a registered index
 
     r = uring.payload.mapRings();
     if (r < 0)
@@ -378,7 +379,8 @@ struct Uring
                     flags |= EnterFlags.SQ_WAKEUP;
                 else return len; // fast poll
             }
-            immutable r = io_uring_enter(payload.fd, len, 0, flags, args);
+            if (payload.regRing) flags |= EnterFlags.ENTER_REGISTERED_RING;
+            immutable r = io_uring_enter(payload.enterFd, len, 0, flags, args);
             if (_expect(r < 0, false)) return -errno;
             payload.sq.submitted(r);
             return r;
@@ -416,7 +418,9 @@ struct Uring
     {
         pragma(inline);
         if (payload.cq.length >= want) return 0; // we don't need to syscall
-        immutable r = io_uring_enter(payload.fd, 0, want, EnterFlags.GETEVENTS, args);
+        EnterFlags flags = EnterFlags.GETEVENTS;
+        if (payload.regRing) flags |= EnterFlags.ENTER_REGISTERED_RING;
+        immutable r = io_uring_enter(payload.enterFd, 0, want, flags, args);
         if (_expect(r < 0, false)) return -errno;
         return 0;
     }
@@ -448,7 +452,8 @@ struct Uring
                 if (_expect(payload.sq.flags & SubmissionQueueFlags.NEED_WAKEUP, false))
                     flags |= EnterFlags.SQ_WAKEUP;
             }
-            immutable r = io_uring_enter(payload.fd, len, want, flags, args);
+            if (payload.regRing) flags |= EnterFlags.ENTER_REGISTERED_RING;
+            immutable r = io_uring_enter(payload.enterFd, len, want, flags, args);
             if (_expect(r < 0, false)) return -errno;
             payload.sq.submitted(r);
             return r;
@@ -643,6 +648,114 @@ struct Uring
     {
         immutable r = io_uring_register(payload.fd, RegisterOpCode.UNREGISTER_EVENTFD, null, 0);
         if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Registers a personality (a snapshot of the calling task's credentials) with the ring.
+     * The returned id can be set on an SQE via `SubmissionEntry.personality` so the request runs
+     * with those credentials. Mirrors liburing's `io_uring_register_personality`.
+     *
+     * Returns: On success, the personality id (`> 0`). On error, `-errno`.
+     */
+    int registerPersonality() @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_PERSONALITY, null, 0);
+        if (_expect(r < 0, false)) return -errno;
+        return r;
+    }
+
+    /**
+     * Unregisters a personality previously obtained from `registerPersonality`.
+     * Mirrors liburing's `io_uring_unregister_personality`.
+     *
+     * Returns: On success, returns 0. On error, `-errno`.
+     */
+    int unregisterPersonality(int id) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.UNREGISTER_PERSONALITY, null, id);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Registers a kernel-side provided-buffer ring (`IORING_REGISTER_PBUF_RING`). `reg` must be
+     * filled with the buffer ring address, entry count and group id; `flags` is OR'd into
+     * `reg.flags` (e.g. `IOU_PBUF_RING_INC`). Mirrors liburing's `io_uring_register_buf_ring`.
+     *
+     * Returns: On success, returns 0. On error, `-errno`.
+     */
+    int registerBufRing(scope ref io_uring_buf_reg reg, uint flags = 0) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        reg.flags = cast(ushort)(reg.flags | flags);
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_PBUF_RING, &reg, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Unregisters the provided-buffer ring with group id `bgid`.
+     * Mirrors liburing's `io_uring_unregister_buf_ring`.
+     *
+     * Returns: On success, returns 0. On error, `-errno`.
+     */
+    int unregisterBufRing(int bgid) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        io_uring_buf_reg reg;
+        reg.bgid = cast(ushort)bgid;
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.UNREGISTER_PBUF_RING, &reg, 1);
+        if (_expect(r < 0, false)) return -errno;
+        return 0;
+    }
+
+    /**
+     * Registers the ring's own file descriptor with the kernel (`IORING_REGISTER_RING_FDS`).
+     * Once registered, `during` transparently passes the registered index plus
+     * `EnterFlags.ENTER_REGISTERED_RING` to every `io_uring_enter(2)`, avoiding the fdget/fdput
+     * cost on each call. Mirrors liburing's `io_uring_register_ring_fd`.
+     *
+     * Returns: On success, returns 0. On error, `-errno` (`-EEXIST` if already registered).
+     */
+    int registerRingFd() @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        if (payload.regRing) return -EEXIST;
+        io_uring_rsrc_update up;
+        up.data = cast(ulong)payload.fd;
+        up.offset = -1U;
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.REGISTER_RING_FDS, &up, 1);
+        if (_expect(r < 0, false)) return -errno;
+        if (r == 1)
+        {
+            payload.enterFd = cast(int)up.offset;
+            payload.regRing = true;
+        }
+        return 0;
+    }
+
+    /**
+     * Reverts `registerRingFd` — subsequent `io_uring_enter(2)` calls use the real ring fd again.
+     * Mirrors liburing's `io_uring_unregister_ring_fd`.
+     *
+     * Returns: On success, returns 0. On error, `-errno` (`-EINVAL` if not registered).
+     */
+    int unregisterRingFd() @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        if (!payload.regRing) return -EINVAL;
+        io_uring_rsrc_update up;
+        up.offset = cast(uint)payload.enterFd;
+        immutable r = io_uring_register(payload.fd, RegisterOpCode.UNREGISTER_RING_FDS, &up, 1);
+        if (_expect(r < 0, false)) return -errno;
+        if (r == 1)
+        {
+            payload.enterFd = payload.fd;
+            payload.regRing = false;
+        }
         return 0;
     }
 
@@ -1037,7 +1150,7 @@ struct Uring
         io_uring_getevents_arg arg;
         arg.sigmask     = cast(ulong)cast(const(void*))sigmask;
         arg.sigmask_sz  = sigmask is null ? 0 : sigset_t.sizeof;
-        arg.pad         = minWaitUsec;          // overlays kernel `min_wait_usec`
+        arg.min_wait_usec = minWaitUsec;
         arg.ts          = cast(ulong)cast(const(void*))&ts;
         return wait!io_uring_getevents_arg(want, &arg);
     }
@@ -1232,6 +1345,32 @@ ref SubmissionEntry prepWritev(V)(return ref SubmissionEntry entry, int fd, ref 
 }
 
 /**
+ * Same as `prepReadv` but additionally sets `rw_flags` (`RWF_*`, e.g. `HIPRI`, `NOWAIT`).
+ * Mirrors liburing's `io_uring_prep_readv2`.
+ */
+ref SubmissionEntry prepReadv2(V)(return ref SubmissionEntry entry, int fd, ref const V buffer, long offset,
+    ReadWriteFlags flags) @trusted
+    if (is(V == iovec[]) || is(V == iovec))
+{
+    entry.prepReadv(fd, buffer, offset);
+    entry.rw_flags = flags;
+    return entry;
+}
+
+/**
+ * Same as `prepWritev` but additionally sets `rw_flags` (`RWF_*`).
+ * Mirrors liburing's `io_uring_prep_writev2`.
+ */
+ref SubmissionEntry prepWritev2(V)(return ref SubmissionEntry entry, int fd, ref const V buffer, long offset,
+    ReadWriteFlags flags) @trusted
+    if ((is(Unqual!V == U[], U) && is(Unqual!U == iovec)) || is(Unqual!V == iovec))
+{
+    entry.prepWritev(fd, buffer, offset);
+    entry.rw_flags = flags;
+    return entry;
+}
+
+/**
  * Prepares `read_fixed` operation.
  *
  * Params:
@@ -1286,6 +1425,18 @@ ref SubmissionEntry prepRecvMsg(return ref SubmissionEntry entry, int fd, ref ms
 {
     entry.prepRW(Operation.RECVMSG, fd, cast(void*)&msg, 1, 0);
     entry.msg_flags = flags;
+    return entry;
+}
+
+/**
+ * Multishot variant of `prepRecvMsg` — keeps posting CQEs for incoming messages until cancelled
+ * or an error occurs. Requires provided buffers. Mirrors liburing's `io_uring_prep_recvmsg_multishot`.
+ */
+ref SubmissionEntry prepRecvmsgMultishot(return ref SubmissionEntry entry, int fd, ref msghdr msg,
+    MsgFlags flags = MsgFlags.NONE) @trusted
+{
+    entry.prepRecvMsg(fd, msg, flags);
+    entry.ioprio = cast(ushort)(entry.ioprio | IORING_RECV_MULTISHOT);
     return entry;
 }
 
@@ -1346,6 +1497,16 @@ ref SubmissionEntry prepPollAdd(return ref SubmissionEntry entry,
     else
         entry.poll_events32 = events;
     return entry;
+}
+
+/**
+ * Multishot variant of `prepPollAdd` — keeps reporting CQEs (each flagged `CQEFlags.MORE`) for
+ * the polled events until cancelled or an error. Mirrors liburing's `io_uring_prep_poll_multishot`.
+ */
+ref SubmissionEntry prepPollMultishot(return ref SubmissionEntry entry,
+    int fd, PollEvents events, PollFlags flags = PollFlags.NONE) @safe
+{
+    return entry.prepPollAdd(fd, events, flags | PollFlags.ADD_MULTI);
 }
 
 /**
@@ -1518,6 +1679,35 @@ ref SubmissionEntry prepAcceptDirect(ADDR)(return ref SubmissionEntry entry, int
 }
 
 /**
+ * Multishot variant of `prepAccept` — keeps accepting incoming connections, posting a CQE per
+ * accepted socket until cancelled or an error. Mirrors liburing's `io_uring_prep_multishot_accept`.
+ *
+ * Note: available from Linux 5.19
+ */
+ref SubmissionEntry prepMultishotAccept(ADDR)(return ref SubmissionEntry entry, int fd, ref ADDR addr,
+    ref socklen_t addrlen, AcceptFlags flags = AcceptFlags.NONE) @trusted
+{
+    entry.prepAccept(fd, addr, addrlen, flags);
+    entry.ioprio = cast(ushort)(entry.ioprio | IORING_ACCEPT_MULTISHOT);
+    return entry;
+}
+
+/**
+ * Same as `prepMultishotAccept`, but accepted fds are installed directly into the fixed file
+ * table; the kernel picks free slots (`IORING_FILE_INDEX_ALLOC`). Mirrors liburing's
+ * `io_uring_prep_multishot_accept_direct`.
+ *
+ * Note: available from Linux 5.19
+ */
+ref SubmissionEntry prepMultishotAcceptDirect(ADDR)(return ref SubmissionEntry entry, int fd, ref ADDR addr,
+    ref socklen_t addrlen, AcceptFlags flags = AcceptFlags.NONE) @trusted
+{
+    entry.prepMultishotAccept(fd, addr, addrlen, flags);
+    entry.file_index = IORING_FILE_INDEX_ALLOC;
+    return entry;
+}
+
+/**
  * Prepares operation that cancels existing async work.
  *
  * This works with any read/write request, accept,send/recvmsg, etc. There’s an important
@@ -1543,6 +1733,18 @@ ref SubmissionEntry prepCancel(D)(return ref SubmissionEntry entry, ref D userDa
 {
     entry.prepRW(Operation.ASYNC_CANCEL, -1, cast(void*)&userData);
     entry.cancel_flags = flags;
+    return entry;
+}
+
+/**
+ * Prepares an async cancel that matches in-flight requests by file descriptor rather than by
+ * `user_data`. Mirrors liburing's `io_uring_prep_cancel_fd`; `IORING_ASYNC_CANCEL_FD` is always
+ * set, additional `CancelFlags` (e.g. `ALL`, `FD_FIXED`) may be passed in `flags`.
+ */
+ref SubmissionEntry prepCancelFd(return ref SubmissionEntry entry, int fd, uint flags = 0) @safe
+{
+    entry.prepRW(Operation.ASYNC_CANCEL, fd, null, 0, 0);
+    entry.cancel_flags = cast(CancelFlags)(flags | CancelFlags.CANCEL_FD);
     return entry;
 }
 
@@ -1675,11 +1877,34 @@ ref SubmissionEntry prepFadvise(return ref SubmissionEntry entry, int fd, long o
 }
 
 /**
+ * 64-bit length variant of `prepFadvise` — `len` is passed in `sqe->addr`, so it is not capped
+ * to 32 bits. Mirrors liburing's `io_uring_prep_fadvise64` (new in liburing 2.9).
+ */
+ref SubmissionEntry prepFadvise64(return ref SubmissionEntry entry, int fd, long offset, ulong len, int advice) @safe
+{
+    entry.prepRW(Operation.FADVISE, fd, null, 0, offset);
+    entry.addr = len;
+    entry.fadvise_advice = advice;
+    return entry;
+}
+
+/**
  * Note: Available from Linux 5.6
  */
 ref SubmissionEntry prepMadvise(return ref SubmissionEntry entry, const(ubyte)[] block, int advice) @trusted
 {
     entry.prepRW(Operation.MADVISE, -1, cast(void*)&block[0], cast(uint)block.length, 0);
+    entry.fadvise_advice = advice;
+    return entry;
+}
+
+/**
+ * 64-bit length variant of `prepMadvise` — the block length is passed in `sqe->off`, so it is
+ * not capped to 32 bits. Mirrors liburing's `io_uring_prep_madvise64` (new in liburing 2.9).
+ */
+ref SubmissionEntry prepMadvise64(return ref SubmissionEntry entry, const(ubyte)[] block, int advice) @trusted
+{
+    entry.prepRW(Operation.MADVISE, -1, cast(void*)&block[0], 0, block.length);
     entry.fadvise_advice = advice;
     return entry;
 }
@@ -1718,6 +1943,27 @@ ref SubmissionEntry prepRecv(return ref SubmissionEntry entry,
     entry.msg_flags = flags;
     entry.buf_group = gid;
     entry.flags |= SubmissionEntryFlags.BUFFER_SELECT;
+    return entry;
+}
+
+/**
+ * Multishot variant of `prepRecv` — keeps posting CQEs for incoming data until cancelled or an
+ * error. Mirrors liburing's `io_uring_prep_recv_multishot`.
+ */
+ref SubmissionEntry prepRecvMultishot(return ref SubmissionEntry entry,
+    int sockfd, ubyte[] buf, MsgFlags flags = MsgFlags.NONE) @trusted
+{
+    entry.prepRecv(sockfd, buf, flags);
+    entry.ioprio = cast(ushort)(entry.ioprio | IORING_RECV_MULTISHOT);
+    return entry;
+}
+
+/// ditto — variant that uses a registered buffer group (the practical multishot setup).
+ref SubmissionEntry prepRecvMultishot(return ref SubmissionEntry entry,
+    int sockfd, ushort gid, uint len, MsgFlags flags = MsgFlags.NONE) @safe
+{
+    entry.prepRecv(sockfd, gid, len, flags);
+    entry.ioprio = cast(ushort)(entry.ioprio | IORING_RECV_MULTISHOT);
     return entry;
 }
 
@@ -1945,6 +2191,31 @@ ref SubmissionEntry prepMsgRing(return ref SubmissionEntry entry,
 }
 
 /**
+ * Sends a (registered) file descriptor `sourceFd` to another ring `fd`, installing it into the
+ * target ring's fixed file table at `targetFd` (or `IORING_FILE_INDEX_ALLOC` to let the kernel
+ * pick a slot). Mirrors liburing's `io_uring_prep_msg_ring_fd`.
+ *
+ * Note: Available from Linux 6.0
+ */
+ref SubmissionEntry prepMsgRingFd(return ref SubmissionEntry entry,
+    int fd, int sourceFd, int targetFd, ulong data, uint flags) @trusted
+{
+    entry.prepRW(Operation.MSG_RING, fd, cast(void*)cast(size_t)IORING_MSG_SEND_FD, 0, data);
+    entry.addr3 = cast(ulong)sourceFd;
+    entry.file_index = (cast(uint)targetFd == IORING_FILE_INDEX_ALLOC)
+        ? IORING_FILE_INDEX_ALLOC : (targetFd + 1);
+    entry.msg_ring_flags = flags;
+    return entry;
+}
+
+/// ditto — variant that always lets the kernel allocate the target slot.
+ref SubmissionEntry prepMsgRingFdAlloc(return ref SubmissionEntry entry,
+    int fd, int sourceFd, ulong data, uint flags) @trusted
+{
+    return entry.prepMsgRingFd(fd, sourceFd, cast(int)IORING_FILE_INDEX_ALLOC, data, flags);
+}
+
+/**
  * Note: Available from Linux 5.19
  */
 ref SubmissionEntry prepGetxattr(return ref SubmissionEntry entry,
@@ -1996,6 +2267,28 @@ ref SubmissionEntry prepSocket(return ref SubmissionEntry entry,
     entry.prepRW(Operation.SOCKET, domain, null, protocol, type);
     entry.rw_flags = cast(ReadWriteFlags)flags;
     return entry;
+}
+
+/**
+ * Same as `prepSocket`, but the created socket is installed directly into the fixed file table
+ * at `fileIndex` (or `IORING_FILE_INDEX_ALLOC` to let the kernel pick a slot). Mirrors
+ * liburing's `io_uring_prep_socket_direct`.
+ */
+ref SubmissionEntry prepSocketDirect(return ref SubmissionEntry entry,
+    int domain, int type, int protocol, uint fileIndex, uint flags) @safe
+{
+    entry.prepRW(Operation.SOCKET, domain, null, protocol, type);
+    entry.rw_flags = cast(ReadWriteFlags)flags;
+    entry.file_index = (fileIndex == IORING_FILE_INDEX_ALLOC)
+        ? IORING_FILE_INDEX_ALLOC : (fileIndex + 1);
+    return entry;
+}
+
+/// ditto — variant that always lets the kernel allocate the fixed file slot.
+ref SubmissionEntry prepSocketDirectAlloc(return ref SubmissionEntry entry,
+    int domain, int type, int protocol, uint flags) @safe
+{
+    return entry.prepSocketDirect(domain, type, protocol, IORING_FILE_INDEX_ALLOC, flags);
 }
 
 /**
@@ -2468,6 +2761,8 @@ struct UringDesc
     nothrow @nogc:
 
     int fd;
+    int enterFd;        // fd (or registered ring index) passed to io_uring_enter(2)
+    bool regRing;       // true once registerRingFd() succeeded
     size_t refs;
     SetupParameters params;
     SubmissionQueue sq;

--- a/tests/helpers.d
+++ b/tests/helpers.d
@@ -1,0 +1,174 @@
+module tests.helpers;
+
+import during;
+import tests.base;
+
+import core.sys.linux.errno;
+import core.sys.linux.fcntl;
+import core.sys.posix.sys.mman : mmap, munmap, MAP_ANON, MAP_FAILED, MAP_PRIVATE, PROT_READ, PROT_WRITE;
+import core.sys.posix.sys.uio : iovec;
+import core.sys.posix.unistd : close, pipe, unlink;
+
+// Minimal smoke tests for the liburing 2.9 helpers added on top of PR #16. These don't aim to
+// re-verify io_uring semantics — just that each new helper builds a valid SQE that the kernel
+// accepts and round-trips.
+
+// registerRingFd registers the ring fd itself; afterwards every io_uring_enter(2) goes through
+// the registered index. A NOP round-trip exercises that enter path, then we unregister.
+@("registerRingFd: enter through a registered ring fd")
+unittest
+{
+    if (!checkKernelVersion(5, 18)) return;
+
+    Uring io;
+    assert(io.setup() >= 0, "Error initializing IO");
+
+    auto rr = io.registerRingFd();
+    if (rr == -EINVAL || rr == -EOPNOTSUPP) return; // not supported on this host
+    assert(rr == 0, "registerRingFd failed");
+
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.user_data = 1; })();
+    assert(io.submit(1) == 1);
+    io.wait(1);
+    assert(io.front.user_data == 1 && io.front.res == 0, "NOP via registered ring failed");
+    io.popFront();
+
+    assert(io.unregisterRingFd() == 0, "unregisterRingFd failed");
+
+    // still usable once the registered fd is gone again
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.user_data = 2; })();
+    assert(io.submit(1) == 1);
+    io.wait(1);
+    assert(io.front.user_data == 2);
+    io.popFront();
+}
+
+@("registerPersonality / unregisterPersonality")
+unittest
+{
+    if (!checkKernelVersion(5, 6)) return;
+
+    Uring io;
+    assert(io.setup() >= 0, "Error initializing IO");
+
+    auto id = io.registerPersonality();
+    if (id == -EINVAL) return; // not supported
+    assert(id > 0, "registerPersonality should return a positive id");
+    assert(io.unregisterPersonality(id) == 0, "unregisterPersonality failed");
+}
+
+// fadvise64 carries the length in sqe->addr (64-bit) instead of sqe->len.
+@("fadvise64")
+unittest
+{
+    if (!checkKernelVersion(5, 6)) return;
+
+    Uring io;
+    assert(io.setup() >= 0, "Error initializing IO");
+
+    auto fname = getTestFileName!"fadvise64_test";
+    auto fd = openFile(fname, O_CREAT | O_RDWR);
+    scope (exit) { close(fd); unlink(&fname[0]); }
+
+    // advice 0 == POSIX_FADV_NORMAL
+    io.putWith!((ref SubmissionEntry e, int f) { e.prepFadvise64(f, 0, 8192, 0); e.user_data = 1; })(fd);
+    assert(io.submit(1) == 1);
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP) return;
+    assert(cqe.res == 0, "fadvise64 failed");
+}
+
+// madvise64 carries the length in sqe->off (64-bit) instead of sqe->len.
+@("madvise64")
+unittest
+{
+    if (!checkKernelVersion(5, 6)) return;
+
+    Uring io;
+    assert(io.setup() >= 0, "Error initializing IO");
+
+    enum len = 8192;
+    auto p = () @trusted {
+        return mmap(null, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    }();
+    assert(p !is MAP_FAILED, "mmap failed");
+    scope (exit) () @trusted { munmap(p, len); }();
+    auto block = () @trusted { return (cast(ubyte*)p)[0 .. len]; }();
+
+    // advice 0 == MADV_NORMAL
+    io.putWith!((ref SubmissionEntry e, ubyte[] b) { e.prepMadvise64(b, 0); e.user_data = 1; })(block);
+    assert(io.submit(1) == 1);
+    io.wait(1);
+    auto cqe = io.front;
+    scope (exit) io.popFront();
+    if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP) return;
+    assert(cqe.res == 0, "madvise64 failed");
+}
+
+// readv2 / writev2 are readv / writev with an extra rw_flags argument.
+@("readv2 / writev2 round-trip")
+unittest
+{
+    Uring io;
+    assert(io.setup() >= 0, "Error initializing IO");
+
+    auto fname = getTestFileName!"readv2_test";
+    auto fd = openFile(fname, O_CREAT | O_RDWR);
+    scope (exit) { close(fd); unlink(&fname[0]); }
+
+    ubyte[64] wbuf = void;
+    foreach (i; 0..64) wbuf[i] = cast(ubyte)i;
+    iovec wv = { iov_base: &wbuf[0], iov_len: 64 };
+
+    io.putWith!((ref SubmissionEntry e, int f, ref iovec v)
+        { e.prepWritev2(f, v, 0, ReadWriteFlags.NONE); e.user_data = 1; })(fd, wv);
+    assert(io.submit(1) == 1);
+    io.wait(1);
+    assert(io.front.res == 64, "writev2 byte count");
+    io.popFront();
+
+    ubyte[64] rbuf = 0;
+    iovec rv = { iov_base: &rbuf[0], iov_len: 64 };
+    io.putWith!((ref SubmissionEntry e, int f, ref iovec v)
+        { e.prepReadv2(f, v, 0, ReadWriteFlags.NONE); e.user_data = 2; })(fd, rv);
+    assert(io.submit(1) == 1);
+    io.wait(1);
+    assert(io.front.res == 64, "readv2 byte count");
+    io.popFront();
+    assert(rbuf == wbuf, "readv2 data mismatch");
+}
+
+// cancelFd matches in-flight requests by file descriptor instead of by user_data.
+@("cancelFd: cancel a poll by fd")
+unittest
+{
+    if (!checkKernelVersion(5, 19)) return; // IORING_ASYNC_CANCEL_FD
+
+    Uring io;
+    assert(io.setup() >= 0, "Error initializing IO");
+
+    int[2] fds;
+    assert(() @trusted { return pipe(fds); }() == 0, "pipe failed");
+    scope (exit) { close(fds[0]); close(fds[1]); }
+
+    // arm a poll that never fires (nothing is ever written to the pipe); submit without
+    // waiting, since the poll only completes once cancelFd cancels it
+    io.putWith!((ref SubmissionEntry e, int rfd)
+        { e.prepPollAdd(rfd, PollEvents.IN); e.user_data = 1; })(fds[0]);
+    assert(io.submit() == 1);
+
+    io.putWith!((ref SubmissionEntry e, int rfd)
+        { e.prepCancelFd(rfd, CancelFlags.CANCEL_ALL); e.user_data = 2; })(fds[0]);
+    assert(io.submit() == 1);
+
+    io.wait(2);
+    foreach (_; 0..2)
+    {
+        auto cqe = io.front;
+        if (cqe.user_data == 1) assert(cqe.res == -ECANCELED, "poll should be cancelled");
+        else assert(cqe.res >= 0, "cancelFd should succeed");
+        io.popFront();
+    }
+}

--- a/tests/package.d
+++ b/tests/package.d
@@ -9,6 +9,7 @@ version (D_BetterC)
     import tests.fixed_fd;
     import tests.fsync;
     import tests.futex;
+    import tests.helpers;
     import tests.msg;
     import tests.pipe;
     import tests.poll;
@@ -31,6 +32,7 @@ version (D_BetterC)
         runTests!("Fixed-fd tests", tests.fixed_fd);
         runTests!("Fsync tests", tests.fsync);
         runTests!("Futex tests", tests.futex);
+        runTests!("Helper tests", tests.helpers);
         runTests!("Msg tests", tests.msg);
         runTests!("Pipe tests", tests.pipe);
         runTests!("Poll tests", tests.poll);

--- a/tests/pipe.d
+++ b/tests/pipe.d
@@ -4,8 +4,16 @@ import during;
 import tests.base;
 
 import core.sys.linux.errno;
-import core.sys.linux.fcntl : O_CLOEXEC;
 import core.sys.posix.unistd : close, read, write;
+
+// O_CLOEXEC was only added to core.sys.posix.fcntl for all platforms in druntime
+// commit 68c97893f8 (2021-07-27), first shipped in DMD 2.098.0. On older frontends
+// the selective import fails, so define it locally there (Linux value, octal
+// 02000000 — identical across x86/x86_64/arm/aarch64).
+static if (__VERSION__ >= 2098)
+    import core.sys.posix.fcntl : O_CLOEXEC;
+else
+    enum O_CLOEXEC = 0x80000;
 
 // Async pipe creation via IORING_OP_PIPE: the kernel populates the int[2] passed in, just
 // like pipe2(2). Verify by writing to fds[1] and reading from fds[0].

--- a/tests/rw.d
+++ b/tests/rw.d
@@ -327,7 +327,8 @@ unittest
             // The (ubyte[][], len, bgid, bid) overload registers `len` buffers of equal size
             // starting at mem.ptr — but we only have two contiguous slabs, so use the slice
             // overload, which feeds one buffer-per-slice at the supplied starting id.
-            ubyte[][2] slabs;
+            ubyte[][2] slabs = void; // both elements assigned below; `= void` avoids the
+                                     // druntime `_memset128` call that breaks the betterC link
             slabs[0] = mem[0..BSZ];
             slabs[1] = mem[BSZ..$];
             e.prepProvideBuffers(slabs[], BSZ, BGID, 0);


### PR DESCRIPTION
Follow-up to PR #16: complete the io_uring.h uapi mirror to v7.1-rc4 (5200f5f4) incl. io_uring_buf_reg layout and msg/zcrx-ctrl constants, add liburing 2.9 helper parity (14 prep/register helpers) with smoke tests, and fix the two CI failures from PR #16 — the O_CLOEXEC import on pre-2.098 frontends and a betterC link error (_memset128) from a default-initialised slice array in tests/rw.d.