### PR TITLE
Follow-up: wait-reg + send-bundle helpers, SQE_MIXED/SQ_REWIND fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: all
 
+BUILD_DIR = build
 SRC_FILES = -Isource/ source/during/*.d
 TEST_FILES = -Itests/ tests/*.d
 TEST_FLAGS = -debug -g -unittest -w -vcolumns
-SILLY_DIR = ~/.dub/packages/silly-1.0.0/silly
+SILLY_DIR = ~/.dub/packages/silly/1.1.1/silly
 SILLY_FILES = -I$(SILLY_DIR) $(SILLY_DIR)/silly.d
 
 ifeq ($(DC),ldc2)
@@ -11,37 +12,40 @@ ifeq ($(DC),ldc2)
 endif
 
 $(SILLY_DIR):
-	dub fetch silly --version="1.0.0"
+	dub fetch silly --version="1.1.1"
 
-buildTestSilly: $(SILLY_DIR)
-	$(DC) -of=during-test -version=test_root $(TEST_FLAGS) $(SRC_FILES) $(TEST_FILES) $(SILLY_FILES)
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
 
-buildTest:
-	$(DC) -of=during-test -version=test_root $(TEST_FLAGS) $(SRC_FILES) $(TEST_FILES)
+buildTestSilly: $(SILLY_DIR) | $(BUILD_DIR)
+	$(DC) -of=$(BUILD_DIR)/during-test -version=test_root $(TEST_FLAGS) $(SRC_FILES) $(TEST_FILES) $(SILLY_FILES)
+
+buildTest: | $(BUILD_DIR)
+	$(DC) -of=$(BUILD_DIR)/during-test -version=test_root $(TEST_FLAGS) $(SRC_FILES) $(TEST_FILES)
 
 test: buildTestSilly
-	./during-test -t 1
+	./$(BUILD_DIR)/during-test -t 1
 
 testPlain: buildTest
-	./during-test
+	./$(BUILD_DIR)/during-test
 
-buildTestBC:
-	$(DC) -of=during-test-bc $(TEST_FLAGS) -betterC $(SRC_FILES) $(TEST_FILES)
+buildTestBC: | $(BUILD_DIR)
+	$(DC) -of=$(BUILD_DIR)/during-test-betterC $(TEST_FLAGS) -betterC $(SRC_FILES) $(TEST_FILES)
 
 testBC: buildTestBC
-	./during-test-bc
+	./$(BUILD_DIR)/during-test-betterC
 
-buildCodecov: $(SILLY_DIR)
-	$(DC) -of=during-test-codecov -version=test_root -cov $(TEST_FLAGS) $(SRC_FILES) $(TEST_FILES) $(SILLY_FILES)
+buildCodecov: $(SILLY_DIR) | $(BUILD_DIR)
+	$(DC) -of=$(BUILD_DIR)/during-test-codecov -version=test_root -cov $(TEST_FLAGS) $(SRC_FILES) $(TEST_FILES) $(SILLY_FILES)
 
 codecov: buildCodecov
-	./during-test-codecov | true
+	./$(BUILD_DIR)/during-test-codecov | true
 
 all: buildTest buildTestBC codecov
 
 clean:
+	- rm -rf $(BUILD_DIR)
 	- rm -f *.a
 	- rm -f *.o
-	- rm -f during-test*
 	- rm -f *.dat
 	- rm -f ./*.lst

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -318,6 +318,15 @@ struct Uring
         return payload.sq.next128();
     }
 
+    version (unittest)
+    const(ubyte)[] debugSubmissionSlotBytes(uint i) @trusted
+    in (payload !is null, "Uring hasn't been initialized yet")
+    {
+        auto ptr = cast(const ubyte*)payload.sq.sqesPtr
+            + cast(size_t)(i & payload.sq.ringMask) * payload.sq.stride;
+        return ptr[0 .. payload.sq.stride];
+    }
+
     /**
      * If completion queue is full, the new event maybe dropped.
      * This value records number of dropped events.
@@ -2941,7 +2950,7 @@ struct SubmissionQueue
         // SQEs it didn't consume must be compacted down to slot 0 to survive the next submit.
         immutable rem = localTail - submitted;
         foreach (i; 0 .. rem)
-            () @trusted { slot(i) = slot(cast(uint)submitted + i); }();
+            copySlot(i, cast(uint)submitted + i);
         localTail = rem;
     }
 
@@ -3063,6 +3072,29 @@ struct SubmissionQueue
 
         localTail = t + 2;
         return t;
+    }
+
+    private ubyte* slotBytes(uint i) @system pure nothrow @nogc return
+    {
+        return cast(ubyte*)sqesPtr + cast(size_t)(i & ringMask) * stride;
+    }
+
+    private void copySlot(uint dst, uint src) @trusted pure nothrow @nogc
+    {
+        auto d = slotBytes(dst);
+        auto s = slotBytes(src);
+        if (d is s) return;
+
+        if (d < s)
+        {
+            foreach (i; 0 .. stride)
+                d[i] = s[i];
+        }
+        else
+        {
+            foreach_reverse (i; 0 .. stride)
+                d[i] = s[i];
+        }
     }
 }
 

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -319,10 +319,10 @@ struct Uring
     }
 
     version (unittest)
-    const(ubyte)[] debugSubmissionSlotBytes(uint i) @trusted
+    ubyte[] debugSubmissionSlotBytes(uint i) @trusted
     in (payload !is null, "Uring hasn't been initialized yet")
     {
-        auto ptr = cast(const ubyte*)payload.sq.sqesPtr
+        auto ptr = cast(ubyte*)payload.sq.sqesPtr
             + cast(size_t)(i & payload.sq.ringMask) * payload.sq.stride;
         return ptr[0 .. payload.sq.stride];
     }
@@ -2992,11 +2992,18 @@ struct SubmissionQueue
     void put()(auto ref SubmissionEntry entry) @trusted pure
     {
         if (sqeMixed && is128Operation(entry.opcode))
-            slot(reserve128Slot()) = entry;
+        {
+            auto idx = reserve128Slot();
+            clearSlot(idx);
+            clearSlot(idx + 1);
+            slot(idx) = entry;
+        }
         else
         {
             assert(!full, "SumbissionQueue is full");
-            slot(localTail++) = entry;
+            auto idx = localTail++;
+            clearSlot(idx);
+            slot(idx) = entry;
         }
     }
 
@@ -3007,14 +3014,16 @@ struct SubmissionQueue
         {
             // The opcode isn't known until the op is materialised, so stage into a temp and
             // route through the 128-aware put() — a NOP128/URING_CMD128 must get two slots.
-            SubmissionEntry e = void;
+            SubmissionEntry e = SubmissionEntry.init;
             () @trusted { e.fill(op); }();
             put(e);
         }
         else
         {
             assert(!full, "SumbissionQueue is full");
-            () @trusted { slot(localTail++).fill(op); }();
+            auto idx = localTail++;
+            clearSlot(idx);
+            () @trusted { slot(idx).fill(op); }();
         }
     }
 
@@ -3035,14 +3044,16 @@ struct SubmissionQueue
         if (sqeMixed)
         {
             // Stage into a temp: FN may build a 128-byte op, which needs the 128-aware path.
-            SubmissionEntry e = void;
+            SubmissionEntry e = SubmissionEntry.init;
             () @trusted { FN(e, args); }();
             put(e);
         }
         else
         {
             assert(!full, "SumbissionQueue is full");
-            () @trusted { FN(slot(localTail++), args); }();
+            auto idx = localTail++;
+            clearSlot(idx);
+            () @trusted { FN(slot(idx), args); }();
         }
     }
 
@@ -3095,6 +3106,13 @@ struct SubmissionQueue
             foreach_reverse (i; 0 .. stride)
                 d[i] = s[i];
         }
+    }
+
+    private void clearSlot(uint idx) @trusted pure nothrow @nogc
+    {
+        auto p = slotBytes(idx);
+        foreach (i; 0 .. stride)
+            p[i] = 0;
     }
 }
 

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -130,6 +130,87 @@ Probe probe() @safe nothrow @nogc
 }
 
 /**
+ * Owns page-aligned memory suitable for `Uring.registerWaitReg`.
+ *
+ * The kernel pins wait-registration regions by page. This helper allocates anonymous mmap
+ * storage sized to whole pages while exposing only the requested number of
+ * `io_uring_reg_wait` entries via `entries`.
+ */
+struct WaitRegRegion
+{
+    io_uring_reg_wait[] entries;
+    private size_t mappingSize;
+    int error;
+
+    @disable this(this);
+
+    ~this() @trusted nothrow @nogc
+    {
+        release();
+    }
+
+    void release() @trusted nothrow @nogc
+    {
+        if (entries.ptr is null) return;
+        munmap(entries.ptr, mappingSize);
+        entries = null;
+        mappingSize = 0;
+    }
+
+    size_t mappingBytes() const @safe pure nothrow @nogc
+    {
+        return mappingSize;
+    }
+
+    T opCast(T)() const @safe pure nothrow @nogc
+        if (is(T == bool))
+    {
+        return entries.ptr !is null;
+    }
+}
+
+/**
+ * Allocate a wait-registration region with `count` usable entries.
+ *
+ * Returns a `WaitRegRegion` with `error == 0` on success. On failure `entries` is empty and
+ * `error` contains `-errno` (or `-EINVAL` for invalid input).
+ */
+WaitRegRegion allocWaitRegRegion(size_t count) @trusted
+{
+    WaitRegRegion region;
+    if (count == 0)
+    {
+        region.error = -EINVAL;
+        return region;
+    }
+
+    immutable pageSize = systemPageSize();
+    if (pageSize == 0 || count > size_t.max / io_uring_reg_wait.sizeof)
+    {
+        region.error = -EINVAL;
+        return region;
+    }
+
+    immutable bytes = roundUpToPage(count * io_uring_reg_wait.sizeof, pageSize);
+    if (bytes == 0)
+    {
+        region.error = -EINVAL;
+        return region;
+    }
+
+    auto ptr = mmap(null, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (ptr == MAP_FAILED)
+    {
+        region.error = -errno;
+        return region;
+    }
+
+    region.entries = (cast(io_uring_reg_wait*)ptr)[0 .. count];
+    region.mappingSize = bytes;
+    return region;
+}
+
+/**
  * Main entry point to work with io_uring.
  *
  * It hides `SubmissionQueue` and `CompletionQueue` behind standard range interface.
@@ -1107,13 +1188,19 @@ struct Uring
     in (payload !is null, "Uring hasn't been initialized yet")
     in (reg.length > 0, "empty wait_reg array")
     {
-        import core.sys.posix.unistd : sysconf, _SC_PAGESIZE;
-        immutable pageSize = cast(size_t)sysconf(_SC_PAGESIZE);
+        immutable pageSize = systemPageSize();
+        immutable addr = cast(size_t)cast(void*)reg.ptr;
+        if (!(payload.params.flags & SetupFlags.R_DISABLED)) return -EINVAL;
+        if (pageSize == 0 || addr % pageSize != 0) return -EINVAL;
+        if (reg.length > size_t.max / io_uring_reg_wait.sizeof) return -EINVAL;
+        immutable byteLen = reg.length * io_uring_reg_wait.sizeof;
+        immutable regionSize = roundUpToPage(byteLen, pageSize);
+        if (regionSize == 0) return -EINVAL;
 
         io_uring_region_desc desc;
         desc.user_addr   = cast(ulong)cast(void*)reg.ptr;
         // Both user_addr and size must be page-aligned (io_create_region rejects otherwise).
-        desc.size        = (reg.length * io_uring_reg_wait.sizeof + pageSize - 1) & ~(pageSize - 1);
+        desc.size        = regionSize;
         desc.flags       = IORING_MEM_REGION_TYPE_USER;
 
         io_uring_mem_region_reg mr;
@@ -3202,6 +3289,20 @@ struct CompletionQueue
 private uint cqeSlots(ref const CompletionEntry cqe) @safe pure nothrow @nogc
 {
     return (cqe.flags & CQEFlags.F_32) ? 2 : 1;
+}
+
+private size_t systemPageSize() @trusted nothrow @nogc
+{
+    import core.sys.posix.unistd : sysconf, _SC_PAGESIZE;
+
+    immutable r = sysconf(_SC_PAGESIZE);
+    return r > 0 ? cast(size_t)r : 0;
+}
+
+private size_t roundUpToPage(size_t value, size_t pageSize) @safe pure nothrow @nogc
+{
+    if (pageSize == 0 || value > size_t.max - (pageSize - 1)) return 0;
+    return ((value + pageSize - 1) / pageSize) * pageSize;
 }
 
 // just a helper to use atomicStore more easily with older compilers

--- a/source/during/package.d
+++ b/source/during/package.d
@@ -2837,6 +2837,19 @@ ref SubmissionEntry prepSendBundle(return ref SubmissionEntry entry,
 }
 
 /**
+ * Convenience variant of `prepSendBundle` for the common provided-buffer-ring case. This keeps
+ * `prepSendBundle` aligned with liburing while still offering a helper that selects `bufGroup`.
+ */
+ref SubmissionEntry prepSendBundleSelect(return ref SubmissionEntry entry,
+    int sockfd, size_t len, ushort bufGroup, MsgFlags flags = MsgFlags.NONE) @safe
+{
+    entry.prepSendBundle(sockfd, len, flags);
+    entry.flags = cast(SubmissionEntryFlags)(entry.flags | SubmissionEntryFlags.BUFFER_SELECT);
+    entry.buf_group = bufGroup;
+    return entry;
+}
+
+/**
  * Attach a destination address to a previously-prepared `prepSend` SQE — turns it into the
  * equivalent of `sendto(2)`. Useful for `SOCK_DGRAM` sockets.
  *

--- a/tests/api.d
+++ b/tests/api.d
@@ -570,3 +570,70 @@ unittest
     assert(io.front.user_data == 3, "leftover NOP completes");
     io.popFront();
 }
+
+@("putWith clears a reused SQE slot before calling the callback")
+unittest
+{
+    Uring io;
+    auto res = io.setup(2);
+    assert(res >= 0, "setup");
+
+    foreach (ud; 0UL .. 2UL)
+        io.putWith!((ref SubmissionEntry e, ulong u) { e.prepNop(); e.user_data = u; })(ud);
+    assert(io.submit(2) == 2);
+    foreach (_; 0 .. 2) io.popFront();
+
+    auto bytes = io.debugSubmissionSlotBytes(0);
+    foreach (ref b; bytes) b = 0xA5;
+
+    io.putWith!((ref SubmissionEntry e)
+    {
+        e.opcode = Operation.NOP;
+        e.fd = -1;
+        e.user_data = 7;
+    });
+
+    auto sqe = cast(const SubmissionEntry*)io.debugSubmissionSlotBytes(0).ptr;
+    assert((*sqe).opcode == Operation.NOP, "opcode");
+    assert((*sqe).fd == -1, "fd");
+    assert((*sqe).user_data == 7, "user_data");
+    assert((*sqe).flags == SubmissionEntryFlags.NONE, "stale flags must be cleared");
+    assert((*sqe).ioprio == 0, "stale ioprio must be cleared");
+    assert((*sqe).addr == 0, "stale addr must be cleared");
+    assert((*sqe).addr3 == 0, "stale addr3 must be cleared");
+}
+
+@("put(custom op) clears a reused SQE slot before fill")
+unittest
+{
+    static struct MinimalNop
+    {
+        Operation opcode;
+        int fd;
+        ulong user_data;
+    }
+
+    Uring io;
+    auto res = io.setup(2);
+    assert(res >= 0, "setup");
+
+    foreach (ud; 0UL .. 2UL)
+        io.putWith!((ref SubmissionEntry e, ulong u) { e.prepNop(); e.user_data = u; })(ud);
+    assert(io.submit(2) == 2);
+    foreach (_; 0 .. 2) io.popFront();
+
+    auto bytes = io.debugSubmissionSlotBytes(0);
+    foreach (ref b; bytes) b = 0x5A;
+
+    MinimalNop op = { opcode: Operation.NOP, fd: -1, user_data: 11 };
+    io.put(op);
+
+    auto sqe = cast(const SubmissionEntry*)io.debugSubmissionSlotBytes(0).ptr;
+    assert((*sqe).opcode == Operation.NOP, "opcode");
+    assert((*sqe).fd == -1, "fd");
+    assert((*sqe).user_data == 11, "user_data");
+    assert((*sqe).flags == SubmissionEntryFlags.NONE, "stale flags must be cleared");
+    assert((*sqe).ioprio == 0, "stale ioprio must be cleared");
+    assert((*sqe).addr == 0, "stale addr must be cleared");
+    assert((*sqe).addr3 == 0, "stale addr3 must be cleared");
+}

--- a/tests/helpers.d
+++ b/tests/helpers.d
@@ -154,6 +154,20 @@ unittest
     assert((e.ioprio & IORING_RECVSEND_BUNDLE) != 0, "BUNDLE flag");
 }
 
+@("prepSendBundleSelect sets buffer selection")
+unittest
+{
+    SubmissionEntry e = void;
+    e.prepSendBundleSelect(7, 8192, 42, MsgFlags.NONE);
+    assert(e.opcode == Operation.SEND, "opcode");
+    assert(e.fd == 7, "fd");
+    assert(e.addr == 0, "bundled send carries no buffer pointer");
+    assert(e.len == 8192, "len is forwarded to sqe->len");
+    assert((e.ioprio & IORING_RECVSEND_BUNDLE) != 0, "BUNDLE flag");
+    assert((e.flags & SubmissionEntryFlags.BUFFER_SELECT) != 0, "buffer select");
+    assert(e.buf_group == 42, "buf group");
+}
+
 // cancelFd matches in-flight requests by file descriptor instead of by user_data.
 @("cancelFd: cancel a poll by fd")
 unittest

--- a/tests/sqe128.d
+++ b/tests/sqe128.d
@@ -209,3 +209,38 @@ unittest
     assert(cqe.res == 0, "NOP128 via putWith must be a valid two-slot op");
     assert(cqe.user_data == 1);
 }
+
+// Regression guard: SQ_REWIND compaction must preserve the full runtime slot width. In an
+// SQE128 ring the trailing cmd[] bytes are in the second half of the slot; copying only the
+// SubmissionEntry header loses payload that real URING_CMD128 users need the kernel to see.
+@("SQ_REWIND preserves SQE128 payload during partial-submit compaction")
+unittest
+{
+    if (!checkKernelVersion(7, 0)) return; // IORING_SETUP_SQ_REWIND
+
+    Uring io;
+    auto res = io.setup(8, SetupFlags.SQ_REWIND | SetupFlags.NO_SQARRAY | SetupFlags.SQE128);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "setup(SQ_REWIND|NO_SQARRAY|SQE128)");
+
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.user_data = 1; });
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.opcode = cast(Operation)0xFF; e.user_data = 2; });
+
+    {
+        auto sqe = &io.next128();
+        (*sqe).prepNop128();
+        sqe.user_data = 3;
+        auto tail = (cast(ubyte*)sqe.cmd.ptr)[0 .. 64];
+        foreach (i, ref b; tail) b = cast(ubyte)(0xA0 ^ i);
+    }
+
+    auto first = io.submit();
+    assert(first == 2, "kernel should consume the good NOP and malformed SQE only");
+
+    io.wait(1);
+    while (!io.empty) io.popFront();
+
+    auto slot = io.debugSubmissionSlotBytes(0);
+    foreach (i; 0 .. 64)
+        assert(slot[64 + i] == cast(ubyte)(0xA0 ^ i), "SQE128 tail payload must survive compaction");
+}

--- a/tests/wait_reg.d
+++ b/tests/wait_reg.d
@@ -4,7 +4,6 @@ import during;
 import tests.base;
 
 import core.sys.linux.errno;
-import core.sys.posix.sys.mman : mmap, munmap, MAP_ANON, MAP_FAILED, MAP_PRIVATE, PROT_READ, PROT_WRITE;
 
 // Posix CLOCK ids exposed by the kernel. CLOCK_BOOTTIME isn't in druntime's posix bindings
 // (it's Linux-specific), so define just the two we need locally.
@@ -50,9 +49,36 @@ unittest
     entries[1].min_wait_usec = 10;
 
     auto rr = io.registerWaitReg(entries[]);
-    // Accept success (regions API enabled) or kernel rejection (older or incomplete).
-    assert(rr == 0 || rr == -EINVAL || rr == -EOPNOTSUPP,
-        "unexpected registerWaitReg result");
+    assert(rr == -EINVAL, "registerWaitReg should reject non-R_DISABLED rings before syscall");
+}
+
+@("allocWaitRegRegion returns page-aligned wait entries")
+unittest
+{
+    import core.sys.posix.unistd : sysconf, _SC_PAGESIZE;
+
+    auto region = allocWaitRegRegion(2);
+    assert(region, "allocWaitRegRegion");
+    assert(region.error == 0, "allocation error");
+    assert(region.entries.length == 2, "entry count");
+    assert(region.mappingBytes >= io_uring_reg_wait.sizeof * 2, "mapping size");
+    immutable pageSize = cast(size_t)sysconf(_SC_PAGESIZE);
+    assert((cast(size_t)cast(void*)region.entries.ptr % pageSize) == 0, "entries must be page aligned");
+}
+
+@("registerWaitReg rejects non-page-aligned slices")
+unittest
+{
+    if (!checkKernelVersion(6, 13)) return;
+
+    Uring io;
+    auto res = io.setup(8, SetupFlags.R_DISABLED);
+    if (res == -EINVAL) return;
+    assert(res >= 0, "setup(R_DISABLED)");
+
+    io_uring_reg_wait[1] entries;
+    auto rr = io.registerWaitReg(entries[]);
+    assert(rr == -EINVAL, "registerWaitReg should reject stack-backed wait entries before syscall");
 }
 
 // Full round-trip through submitAndWaitReg. Pre-fix the EXT_ARG_REG enter was mis-wired
@@ -70,15 +96,9 @@ unittest
     if (res == -EINVAL) return;
     assert(res >= 0, "setup(R_DISABLED)");
 
-    // The WAIT_ARG region must be page-aligned, whole-page memory.
-    enum pageSz = 4096;
-    auto p = () @trusted {
-        return mmap(null, pageSz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
-    }();
-    assert(p !is MAP_FAILED, "mmap");
-    scope (exit) () @trusted { munmap(p, pageSz); }();
-
-    auto regs = () @trusted { return (cast(io_uring_reg_wait*)p)[0 .. 1]; }();
+    auto region = allocWaitRegRegion(1);
+    assert(region, "allocWaitRegRegion");
+    auto regs = region.entries;
     regs[0].ts = KernelTimespec(0, 10_000_000); // 10ms
     regs[0].flags = IORING_REG_WAIT_TS;
 


### PR DESCRIPTION
## Summary

Follow-up polish to the liburing 2.9 / Linux 7.1-rc4 catch-up landed in #16, #17, and the two most recent master commits (85a24ad "finish liburing 2.9 / Linux 7.1-rc4 sync", ee98273 "correctness bugs in the liburing-2.9 / 7.1-rc4 work"). Two more correctness fixes against the new SQE_MIXED / SQ_REWIND storage paths, two convenience helpers that round out the new register/op surface, and one build-infra alignment with `dub.sdl`.

## What's in here

**Correctness fixes (continuation of `ee98273`'s pass):**

- `fix: preserve full SQE slots during rewind compaction` (`58b9df2`) —   `SQ_REWIND` compaction was assigning `SubmissionEntry` values, which only copies the 64-byte SQE header and silently drops the trailing payload on `SQE128` rings. Real `URING_CMD128` users can depend on those bytes. Regression test combines `SQ_REWIND` + `SQE128`, forces   a partial submit, and verifies the 128-byte payload survives.
- `fix: clear SQE slots before staged insertion` (`82d0109`) — the `putWith` contract documents that the SQE is cleared before the user callback fills it, but the implementation reused the mmap slot as-is, leaking stale flags, personality ids, or address fields into callbacks that only set a minimal op. Now clears the full runtime
  slot (both physical slots for 128-byte ops on `SQE_MIXED` rings) before `putWith` / custom-op fill. Regression poisons a reused slot and asserts untouched fields come back zero.

**New helpers:**

- `feat: add safe wait-reg region allocation` (`cdbc65a`) — `REGISTER_MEM_REGION` wait args require a page-aligned user address, a page-sized backing region, and an `R_DISABLED` ring. The previous wrapper documented those constraints but still let callers make
  invalid syscalls with ordinary D slices. Adds `WaitRegRegion` / `allocWaitRegRegion` for mmap-backed lifecycle, validates the three preconditions, and guards against stack-backed slices / non-disabled rings in tests.
- `feat: add buffered send-bundle convenience helper` (`56dd155`) — `prepSendBundle` mirrors liburing strictly: it leaves `IOSQE_BUFFER_SELECT` and `buf_group` to the caller. That removed the ergonomic one-call path for provided-buffer-ring setup. Adds  `prepSendBundleSelect` as an explicit convenience helper layered on top, with smoke tests covering both surfaces.

**Build:**

- `build(make): route artifacts to build/ and align with dub.sdl` (`1585b4c`) — Makefile now mirrors `dub.sdl`'s `targetPath "build"` and `targetName "during-test-betterC"` so `make` and `dub` produce equivalent outputs. Also fixes the `dub fetch silly` version to the resolved `1.1.1` path.

## Test plan

- [x] `dub test -- --threads=1` — all unit tests pass, including the four new regression tests (rewind+SQE128 payload, putWith slot clearing, custom-op slot clearing, wait-reg page-alignment guards) and the two new helper smoke tests.
- [x] `make test` — `during-test` builds into `build/` and runs green.
- [x] `make testBC` — `build/during-test-betterC` builds and runs green.
- [x] `dub build --config=betterC` — green.
- [x] Probed on kernel `6.18.17`; kernel-gated tests stay gated via `checkKernelVersion()`.

## Test environment

Same as #16: NixOS 25.11, kernel `6.18.17` x86_64, AMD Ryzen 9 7940HX, LDC 1.41.0 (DMD v2.111.0 frontend, LLVM 18.1.8), dub 1.39.0. Toolchain pinned by the `flake.nix` introduced in #16.